### PR TITLE
Register reason for accessing decrypted data and other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ a JSON entry that looks like this:
   "console": {
     "user": "Jorge",
     "reason": "fix something",
-    "statements": "Account.first\n"
+    "commands": "Account.first\n"
   },
   "rails": {
     "application": "haystack",

--- a/lib/console1984/access_reason.rb
+++ b/lib/console1984/access_reason.rb
@@ -1,0 +1,15 @@
+class Console1984::AccessReason
+  %i[ for_session for_commands for_sensitive_access ].each do |attribute_name|
+    attr_reader attribute_name
+
+    define_method "#{attribute_name}=" do |value|
+      validate_not_empty(value) if send(attribute_name).present?
+      instance_variable_set "@#{attribute_name}", value
+    end
+  end
+
+  private
+    def validate_not_empty(value)
+      raise ArgumentError, "Value can't be blank" if value.blank?
+    end
+end

--- a/lib/console1984/audit_trail.rb
+++ b/lib/console1984/audit_trail.rb
@@ -1,1 +1,11 @@
-Console1984::AuditTrail = Struct.new(:user, :reason, :statements, :sensitive, keyword_init: true)
+class Console1984::AuditTrail
+  attr_reader :session_id, :user, :commands, :access_reason, :sensitive
+
+  def initialize(session_id:, user:, access_reason:, commands:, sensitive: false)
+    @session_id = session_id
+    @user = user
+    @access_reason = access_reason
+    @commands = commands
+    @sensitive = sensitive
+  end
+end

--- a/lib/console1984/audit_trail_serializer.rb
+++ b/lib/console1984/audit_trail_serializer.rb
@@ -3,10 +3,16 @@ module Console1984
     def serialize
       encode do |json|
         json.console do
+          json.session_id audit_trail.session_id
           json.user audit_trail.user
-          json.reason audit_trail.reason
-          json.statements audit_trail.statements
+          json.commands audit_trail.commands
           json.sensitive audit_trail.sensitive
+
+          json.access_reason do
+            json.for_session audit_trail.access_reason.for_session
+            json.for_commands audit_trail.access_reason.for_commands
+            json.for_sensitive_access audit_trail.access_reason.for_sensitive_access
+          end
         end
       end
     end

--- a/lib/console1984/commands.rb
+++ b/lib/console1984/commands.rb
@@ -1,9 +1,22 @@
 module Console1984::Commands
   def decrypt!
-    Console1984.supervisor.enable_access_to_encrypted_content
+    supervisor.enable_access_to_encrypted_content
   end
 
   def encrypt!
-    Console1984.supervisor.disable_access_to_encrypted_content
+    supervisor.disable_access_to_encrypted_content
   end
+
+  def log(new_reason)
+    supervisor.access_reason.for_commands = new_reason
+  end
+
+  def consent(new_consent)
+    supervisor.access_reason.for_sensitive_access = new_consent
+  end
+
+  private
+    def supervisor
+      Console1984.supervisor
+    end
 end

--- a/lib/console1984/messages.rb
+++ b/lib/console1984/messages.rb
@@ -1,17 +1,27 @@
 module Console1984::Messages
   PRODUCTION_DATA_WARNING = <<~TXT
-    This environment contains production data. The commands you type will be audited.
-    
-    Willful, unauthorized access carries the penalty of termination or prosecution.
+
+  You have access to production data here. That's a big deal. As part of our promise to keep customer data safe and private, we audit the commands you type here. Let's get started!
   TXT
 
   ENTER_UNPROTECTED_ENCRYPTION_MODE_WARNING = <<~TXT
-  You have enabled access to encrypted information. This access will be flagged and subject to special auditing.
-
-  You can go back to protected mode with 'encrypt!'
+  Ok! You have access to encrypted information now. We pay extra close attention to any commands entered while you have this access. You can go back to protected mode with 'encrypt!'
   TXT
 
   ENTER_PROTECTED_MODE_WARNING = <<~TXT
-  You have disabled access to encrypted information
+  Great! You are back in protected mode. When we audit, we may reach out for a conversation about the commands you entered. What went well? Did you solve the problem without accessing personal data?
+  TXT
+
+  COMMANDS = {
+      "decrypt!": "enter unprotected mode with access to encrypted information",
+      "log '<reason>'": "provide further information about what you are going to do in the middle of a console session"
+  }
+
+  COMMANDS_HELP = <<~TXT
+  
+  Commands:
+
+  #{COMMANDS.collect { |command, help_line| "* #{ColorizedString.new(command.to_s).light_blue}: #{help_line}" }.join("\n")}
+
   TXT
 end

--- a/lib/console1984/supervisor/encryption_mode.rb
+++ b/lib/console1984/supervisor/encryption_mode.rb
@@ -2,13 +2,14 @@ module Console1984::Supervisor::EncryptionMode
   include Console1984::Messages
 
   def enable_access_to_encrypted_content(silent: false)
-    show_warning ENTER_UNPROTECTED_ENCRYPTION_MODE_WARNING  unless silent
+    access_reason.for_sensitive_access = ask_for_value "\nBefore you can access personal information, you need to ask for and get explicit consent from the user(s). #{user_name}, where can we find this consent (a URL would be great)?"
+    show_warning ENTER_UNPROTECTED_ENCRYPTION_MODE_WARNING if !silent && protected_mode?
     @encryption_mode = Unprotected.new
     nil
   end
 
   def disable_access_to_encrypted_content(silent: false)
-    show_warning ENTER_PROTECTED_MODE_WARNING unless silent
+    show_warning ENTER_PROTECTED_MODE_WARNING if !silent && unprotected_mode?
     @encryption_mode = Protected.new
     nil
   end
@@ -19,5 +20,9 @@ module Console1984::Supervisor::EncryptionMode
 
   def unprotected_mode?
     @encryption_mode.is_a?(Unprotected)
+  end
+
+  def protected_mode?
+    !unprotected_mode?
   end
 end

--- a/lib/console1984/supervisor/input_output.rb
+++ b/lib/console1984/supervisor/input_output.rb
@@ -1,0 +1,11 @@
+module Console1984::Supervisor::InputOutput
+  def show_warning(message)
+    puts ColorizedString.new("\n#{message}\n").yellow
+  end
+
+  def ask_for_value(message)
+    puts ColorizedString.new("#{message}").green
+    reason = $stdin.gets.strip until reason.present?
+    reason
+  end
+end

--- a/test/auditing_test.rb
+++ b/test/auditing_test.rb
@@ -9,7 +9,7 @@ class AuditingTest < ActiveSupport::TestCase
     @console.stop
   end
 
-  test "executing statements show the output" do
+  test "executing commands show the output" do
     @console.execute <<~RUBY
       puts "Result is \#{1+1}"
     RUBY
@@ -17,17 +17,21 @@ class AuditingTest < ActiveSupport::TestCase
     assert @console.output.include?("Result is 2")
   end
 
-  test "executing statements log an audit trail with reason, user and executed statements" do
+  test "executing commands log an audit trail with reason, user and executed commands" do
     @console.execute "1+1"
     audit_trail = @console.last_audit_trail
-    assert_audit_trail audit_trail, user: "jorge", reason: "Some very good reason", statements: "1+1"
+    assert_audit_trail audit_trail, user: "jorge", commands: "1+1" do |access_reason|
+      assert_equal "Some very good reason", access_reason.for_session
+    end
   end
 
-  test "can execute multiple statements" do
-    %w[ 1+1 2+2 3+3 ].each do |statements|
-      @console.execute statements
+  test "can execute multiple commands" do
+    %w[ 1+1 2+2 3+3 ].each do |commands|
+      @console.execute commands
       audit_trail = @console.last_audit_trail
-      assert_audit_trail audit_trail, user: "jorge", reason: "Some very good reason", statements: statements
+      assert_audit_trail audit_trail, user: "jorge", commands: commands do |access_reason|
+        assert_equal "Some very good reason", access_reason.for_session
+      end
     end
   end
 
@@ -41,10 +45,23 @@ class AuditingTest < ActiveSupport::TestCase
     assert_not @console.last_audit_trail.sensitive
   end
 
-  test "commands in unprotected mode are flagged as sensitive" do
-    @console.execute "decrypt!"
+  test "can log further reasons with the log command" do
+    @console.execute "log 'I really need the name OMG'"
     @console.execute "puts Person.last.name"
-    assert @console.last_audit_trail.sensitive
+    assert_audit_trail @console.last_audit_trail, sensitive: false do |access_reason|
+      assert_equal "I really need the name OMG", access_reason.for_commands
+    end
+  end
+
+  test "commands in unprotected mode are justified and flagged as sensitive" do
+    type_when_prompted "I need to fix encoding issue with Message 123456" do
+      @console.execute "decrypt!"
+    end
+    @console.execute "puts Person.last.name"
+
+    assert_audit_trail @console.last_audit_trail, sensitive: true do |access_reason|
+      assert_equal "I need to fix encoding issue with Message 123456", access_reason.for_sensitive_access
+    end
   end
 
   private
@@ -52,5 +69,7 @@ class AuditingTest < ActiveSupport::TestCase
       expected_properties.each do |key, value|
         assert_equal value, audit_trail.send(key)
       end
+
+      yield audit_trail.access_reason
     end
 end

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -19,7 +19,7 @@ class EncryptionTest < ActiveSupport::TestCase
   end
 
   test "decrypt! will reveal encrypted attributes" do
-    @console.execute "decrypt!"
+    execute_decrypt_and_enter_reason
 
     @console.execute <<~RUBY
       puts Person.find(#{@person.id}).name
@@ -29,7 +29,7 @@ class EncryptionTest < ActiveSupport::TestCase
   end
 
   test "encrypt! will hide encrypted attributes" do
-    @console.execute "decrypt!"
+    execute_decrypt_and_enter_reason
     @console.execute "encrypt!"
 
     @console.execute <<~RUBY
@@ -49,7 +49,7 @@ class EncryptionTest < ActiveSupport::TestCase
   end
 
   test "can modify unencrypted attributes in unprotected mode" do
-    @console.execute "decrypt!"
+    execute_decrypt_and_enter_reason
 
     assert_nothing_raised do
       @console.execute <<~RUBY
@@ -62,7 +62,7 @@ class EncryptionTest < ActiveSupport::TestCase
   end
 
   test "can modify encrypted attributes in unprotected mode" do
-    @console.execute "decrypt!"
+    execute_decrypt_and_enter_reason
 
     assert_nothing_raised do
       @console.execute <<~RUBY
@@ -73,4 +73,11 @@ class EncryptionTest < ActiveSupport::TestCase
 
     assert_equal "Other name", @person.reload.name
   end
+
+  private
+    def execute_decrypt_and_enter_reason
+      type_when_prompted "I need to fix encoding issue with Message 123456" do
+        @console.execute "decrypt!"
+      end
+    end
 end


### PR DESCRIPTION
This adds a number of refinements:

- Adds a `session_id` to all the commands executed in a given session, so that we can group them all under the same key.
- Ask for a consent when accessing encrypted content mode with `decrypt!`
- Review the message copies according to [this message](https://3.basecamp.com/2914079/buckets/14968485/todos/2724436300#__recording_2724607188)
- Add a `log("reason")` command to add further info about the commands you are going to execute when in the middle of a console session
- Print a summary of available commands when starting the console
- Renames "statements" to "commands" internally and in the logs

```json
{
  "console": {
    "session_id": "ukrZS34oIY",
    "user": "Jorge",
    "commands": "puts 'Hello world'",
    "sensitive": false,
    "access_reason": {
      "for_session": "troubleshoot bug #1234",
      "for_sensitive_access": "https://my.consent.com",
      "for_commands": "I need to tweak encoding of message"
    }
  }
}
```

@basecamp/sip 