### PR TITLE
Intercept redis' sockets too

### DIFF
--- a/lib/console1984.rb
+++ b/lib/console1984.rb
@@ -14,8 +14,13 @@ module Console1984
   thread_mattr_accessor :currently_protected_urls
 
   class << self
-    def install_support
-      [TCPSocket, OpenSSL::SSL::SSLSocket].each do |socket_klass|
+    def patch_socket_classes
+      socket_classes = [ TCPSocket, OpenSSL::SSL::SSLSocket ]
+      if defined?(Redis::Connection)
+        socket_classes.push *[ Redis::Connection::TCPSocket, Redis::Connection::SSLSocket ]
+      end
+
+      socket_classes.compact.each do |socket_klass|
         socket_klass.prepend Console1984::ProtectedTcpSocket
       end
     end

--- a/lib/console1984/engine.rb
+++ b/lib/console1984/engine.rb
@@ -16,7 +16,7 @@ module Console1984
 
       Console1984.supervisor.start if Console1984.running_protected_environment?
 
-      Console1984.install_support
+      Console1984.patch_socket_classes
 
       class OpenSSL::SSL::SSLSocket
         # Make it serve remote address as TCPSocket so that our extension works for it

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,7 +32,7 @@ ActiveRecord::Encryption.configure \
   key_derivation_salt: "testing key derivation salt",
   support_unencrypted_data: true
 
-Console1984.install_support
+Console1984.patch_socket_classes
 
 class ActiveSupport::TestCase
   setup do


### PR DESCRIPTION
It turns out `redis` uses its own socket extensions internally

@basecamp/sip 