### PR TITLE
Fix kwargs when overriding database methods

### DIFF
--- a/lib/console1984/protected_auditable_tables.rb
+++ b/lib/console1984/protected_auditable_tables.rb
@@ -3,12 +3,12 @@ module Console1984::ProtectedAuditableTables
   include Console1984::Freezeable
 
   %i[ execute exec_query exec_insert exec_delete exec_update exec_insert_all ].each do |method|
-    define_method method do |*args|
+    define_method method do |*args, **kwargs|
       sql = args.first
       if Console1984.supervisor.executing_user_command? && sql =~ auditable_tables_regexp
         raise Console1984::Errors::ForbiddenCommand, "#{sql}"
       else
-        super(*args)
+        super(*args, **kwargs)
       end
     end
   end


### PR DESCRIPTION
Was trying this out tonight on Postgres and we ran into this error because the PG adapter uses a keyword arg.

```ruby
Unnamed, why are you using this console today?
hello
/Users/andreafomera/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-0a4410dace9a/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb:51:in `exec_query': wrong number of arguments (given 4, expected 1..3) (ArgumentError)
    from /Users/andreafomera/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/console1984-d18a1b75668a/lib/console1984/protected_auditable_tables.rb:11:in `block (2 levels) in <module:ProtectedAuditableTables>'
    from /Users/andreafomera/.asdf/installs/ruby/3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-0a4410dace9a/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb:547:in `select'
```

Passing along the kwargs did the trick. 👍 

Co-authored-by: Andrea Fomera <afomera@hey.com>