### PR TITLE
Protect dynamic extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ Performance:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Lint/UselessAssignment:
+  Enabled: false
+
 Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes

--- a/config/protections.yml
+++ b/config/protections.yml
@@ -1,12 +1,14 @@
-static_validations:
+validations:
   forbidden_reopening:
     - ActiveRecord
     - Console1984
     - PG
     - Mysql2
+    - IRB
   forbidden_constant_reference:
     always:
       - Console1984
+      - IRB
     protected:
       - PG
       - Mysql2
@@ -16,15 +18,14 @@ static_validations:
     - Console1984
     - secret
     - credentials
+    - irb
 forbidden_methods:
-  always:
-  user:
-    Kernel:
-      - eval
-    Object:
-      - eval
-    BasicObject:
-      - eval
-      - instance_eval
-    Module:
-      - class_eval
+  Kernel:
+    - eval
+  Object:
+    - eval
+  BasicObject:
+    - eval
+    - instance_eval
+  Module:
+    - class_eval

--- a/lib/console1984/command_executor.rb
+++ b/lib/console1984/command_executor.rb
@@ -19,11 +19,14 @@ class Console1984::CommandExecutor
     run_as_system { session_logger.before_executing commands }
     validate_command commands
     execute_in_protected_mode(&block)
-  rescue Console1984::Errors::ForbiddenCommand, FrozenError
+  rescue Console1984::Errors::ForbiddenCommandAttempted, FrozenError
     flag_suspicious(commands)
-  rescue Console1984::Errors::SuspiciousCommand
+  rescue Console1984::Errors::SuspiciousCommandAttempted
     flag_suspicious(commands)
     execute_in_protected_mode(&block)
+  rescue Console1984::Errors::ForbiddenCommandExecuted
+    flag_suspicious(commands)
+    Console1984.supervisor.stop
   ensure
     run_as_system { session_logger.after_executing commands }
   end

--- a/lib/console1984/command_validator.rb
+++ b/lib/console1984/command_validator.rb
@@ -5,7 +5,7 @@
 #
 # The validation itself happens as a chain of validation objects. The system will invoke
 # each validation in order. Validations will raise an error if the validation fails (typically
-# a Console1984::Errors::ForbiddenCommand or Console1984::Errors::SuspiciousCommands).
+# a Console1984::Errors::ForbiddenCommandAttempted or Console1984::Errors::SuspiciousCommands).
 #
 # Internally, validations will receive a Console1984::CommandValidator::ParsedCommand object. This
 # exposes parsed constructs in addition to the raw strings so that validations can use those.

--- a/lib/console1984/command_validator/forbidden_constant_reference_validation.rb
+++ b/lib/console1984/command_validator/forbidden_constant_reference_validation.rb
@@ -18,7 +18,7 @@ class Console1984::CommandValidator::ForbiddenConstantReferenceValidation
   def validate(parsed_command)
     if contains_invalid_const_reference?(parsed_command, @forbidden_constants_names) ||
       (@shield.protected_mode? && contains_invalid_const_reference?(parsed_command, @constant_names_forbidden_in_protected_mode))
-      raise Console1984::Errors::ForbiddenCommand
+      raise Console1984::Errors::ForbiddenCommandAttempted
     end
   end
 

--- a/lib/console1984/command_validator/forbidden_constant_reference_validation.rb
+++ b/lib/console1984/command_validator/forbidden_constant_reference_validation.rb
@@ -14,7 +14,7 @@ class Console1984::CommandValidator::ForbiddenConstantReferenceValidation
     @constant_names_forbidden_in_protected_mode = config[:protected] || []
   end
 
-  # Raises a Console1984::Errors::ForbiddenCommand if a banned constant is referenced.
+  # Raises a Console1984::Errors::ForbiddenCommandAttempted if a banned constant is referenced.
   def validate(parsed_command)
     if contains_invalid_const_reference?(parsed_command, @forbidden_constants_names) ||
       (@shield.protected_mode? && contains_invalid_const_reference?(parsed_command, @constant_names_forbidden_in_protected_mode))

--- a/lib/console1984/command_validator/forbidden_reopening_validation.rb
+++ b/lib/console1984/command_validator/forbidden_reopening_validation.rb
@@ -8,7 +8,7 @@ class Console1984::CommandValidator::ForbiddenReopeningValidation
     @banned_class_or_module_names = banned_classes_or_modules.collect(&:to_s)
   end
 
-  # Raises a Console1984::Errors::ForbiddenCommand if an banned class or module reopening
+  # Raises a Console1984::Errors::ForbiddenCommandAttempted if an banned class or module reopening
   # is detected.
   def validate(parsed_command)
     if contains_invalid_class_or_module_declaration?(parsed_command)

--- a/lib/console1984/command_validator/forbidden_reopening_validation.rb
+++ b/lib/console1984/command_validator/forbidden_reopening_validation.rb
@@ -12,7 +12,7 @@ class Console1984::CommandValidator::ForbiddenReopeningValidation
   # is detected.
   def validate(parsed_command)
     if contains_invalid_class_or_module_declaration?(parsed_command)
-      raise Console1984::Errors::ForbiddenCommand
+      raise Console1984::Errors::ForbiddenCommandAttempted
     end
   end
 

--- a/lib/console1984/command_validator/parsed_command.rb
+++ b/lib/console1984/command_validator/parsed_command.rb
@@ -76,7 +76,7 @@ class Console1984::CommandValidator::ParsedCommand
 
       def on_casgn(node)
         super
-        scope_node, name, value_node = *node
+        _scope_node, name, value_node = *node
         @constant_assignments.push(*extract_constants(value_node))
       end
 

--- a/lib/console1984/command_validator/suspicious_terms_validation.rb
+++ b/lib/console1984/command_validator/suspicious_terms_validation.rb
@@ -9,7 +9,7 @@ class Console1984::CommandValidator::SuspiciousTermsValidation
   # Raises a Console1984::Errors::SuspiciousCommand if the term is referenced.
   def validate(parsed_command)
     if contains_suspicious_term?(parsed_command)
-      raise Console1984::Errors::SuspiciousCommand
+      raise Console1984::Errors::SuspiciousCommandAttempted
     end
   end
 

--- a/lib/console1984/errors.rb
+++ b/lib/console1984/errors.rb
@@ -10,11 +10,15 @@ module Console1984
 
     # Attempt to execute a command that is not allowed. The system won't
     # execute such commands and will flag them as sensitive.
-    class ForbiddenCommand < StandardError; end
+    class ForbiddenCommandAttempted < StandardError; end
 
     # A suspicious command was executed. The command will be flagged but the system
     # will let it run.
-    class SuspiciousCommand < StandardError; end
+    class SuspiciousCommandAttempted < StandardError; end
+
+    # A forbidden command was executed. The system will flag the command
+    # and exit.
+    class ForbiddenCommandExecuted < StandardError; end
 
     # Attempt to incinerate a session ahead of time as determined by
     # +config.console1984.incinerate_after+.

--- a/lib/console1984/ext/active_record/protected_auditable_tables.rb
+++ b/lib/console1984/ext/active_record/protected_auditable_tables.rb
@@ -6,7 +6,7 @@ module Console1984::Ext::ActiveRecord::ProtectedAuditableTables
     define_method method do |*args, **kwargs|
       sql = args.first
       if Console1984.command_executor.executing_user_command? && sql =~ auditable_tables_regexp
-        raise Console1984::Errors::ForbiddenCommand, "#{sql}"
+        raise Console1984::Errors::ForbiddenCommandAttempted, "#{sql}"
       else
         super(*args, **kwargs)
       end

--- a/lib/console1984/ext/core/module.rb
+++ b/lib/console1984/ext/core/module.rb
@@ -7,7 +7,7 @@ module Console1984::Ext::Core::Module
 
   def instance_eval(*)
     if Console1984.command_executor.executing_user_command?
-      raise Console1984::Errors::ForbiddenCommand
+      raise Console1984::Errors::ForbiddenCommandAttempted
     else
       super
     end

--- a/lib/console1984/ext/core/module.rb
+++ b/lib/console1984/ext/core/module.rb
@@ -12,4 +12,21 @@ module Console1984::Ext::Core::Module
       super
     end
   end
+
+  def method_added(method)
+    if Console1984.command_executor.from_irb?(caller) && banned_for_reopening?
+      raise Console1984::Errors::ForbiddenCommandExecuted, "Trying to add method `#{method}` to #{self.name}"
+    end
+  end
+
+  private
+    def banned_for_reopening?
+      classes_and_modules_banned_for_reopening.find do |banned_class_or_module_name|
+        "#{self.name}::".start_with?("#{banned_class_or_module_name}::")
+      end
+    end
+
+    def classes_and_modules_banned_for_reopening
+      @classes_and_modules_banned_for_reopening ||= Console1984.protections_config.validations[:forbidden_reopening]
+    end
 end

--- a/lib/console1984/ext/core/object.rb
+++ b/lib/console1984/ext/core/object.rb
@@ -25,7 +25,7 @@ module Console1984::Ext::Core::Object
           # See the list +forbidden_reopening+ in +config/command_protections.yml+.
           Console1984.command_executor.validate_command("class #{arguments.first}; end")
           super
-        rescue Console1984::Errors::ForbiddenCommand
+        rescue Console1984::Errors::ForbiddenCommandAttempted
           raise
         rescue StandardError
           super

--- a/lib/console1984/freezeable.rb
+++ b/lib/console1984/freezeable.rb
@@ -39,7 +39,7 @@ module Console1984::Freezeable
     private
       def prevent_sensitive_method(method_name)
         define_method method_name do |*arguments|
-          raise Console1984::Errors::ForbiddenCommand, "You can't invoke #{method_name} on #{self}"
+          raise Console1984::Errors::ForbiddenCommandAttempted, "You can't invoke #{method_name} on #{self}"
         end
       end
   end

--- a/lib/console1984/protections_config.rb
+++ b/lib/console1984/protections_config.rb
@@ -1,7 +1,7 @@
 class Console1984::ProtectionsConfig
   include Console1984::Freezeable
 
-  delegate :static_validations, to: :instance
+  delegate :validations, to: :instance
 
   attr_reader :config
 
@@ -9,7 +9,7 @@ class Console1984::ProtectionsConfig
     @config = config
   end
 
-  %i[ static_validations forbidden_methods ].each do |method_name|
+  %i[ validations forbidden_methods ].each do |method_name|
     define_method method_name do
       config[method_name].symbolize_keys
     end

--- a/lib/console1984/shield/method_invocation_shell.rb
+++ b/lib/console1984/shield/method_invocation_shell.rb
@@ -3,22 +3,20 @@ class Console1984::Shield::MethodInvocationShell
   include Console1984::Freezeable
 
   class << self
-    def install_for(config)
-      Array(config[:user]).each { |invocation| self.new(invocation, only_for_user_commands: true).prevent_methods_invocation }
-      Array(config[:system]).each { |invocation| self.new(invocation, only_for_user_commands: false).prevent_methods_invocation }
+    def install_for(invocations)
+      Array(invocations).each { |invocation| self.new(invocation).prevent_methods_invocation }
     end
   end
 
   attr_reader :class_name, :methods, :only_for_user_commands
 
-  def initialize(invocation, only_for_user_commands:)
+  def initialize(invocation)
     @class_name, methods = invocation.to_a
     @methods = Array(methods)
-    @only_for_user_commands = only_for_user_commands
   end
 
   def prevent_methods_invocation
-    class_name.constantize.prepend build_protection_module
+    class_name.to_s.constantize.prepend build_protection_module
   end
 
   def build_protection_module
@@ -37,12 +35,8 @@ class Console1984::Shield::MethodInvocationShell
   def protected_method_invocation_source_for(method)
     <<~RUBY
       def #{method}(*args)
-        if (!#{only_for_user_commands} || Console1984.command_executor.executing_user_command?) && caller.find do |line|
-            line_from_irb = line =~ /^[^\\/]/
-            break if !(line =~ /console1984\\/lib/ || line_from_irb)
-            line_from_irb
-          end
-          raise Console1984::Errors::ForbiddenCommand
+        if Console1984.command_executor.from_irb?(caller)
+          raise Console1984::Errors::ForbiddenCommandAttempted
         else
           super
         end

--- a/lib/console1984/supervisor.rb
+++ b/lib/console1984/supervisor.rb
@@ -30,6 +30,11 @@ class Console1984::Supervisor
     stop_session
   end
 
+  def exit_irb
+    stop
+    IRB.CurrentContext.exit
+  end
+
   private
     def require_dependencies
       Kernel.silence_warnings do

--- a/test/command_validator/forbidden_constant_reference_validation_test.rb
+++ b/test/command_validator/forbidden_constant_reference_validation_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
   test "validate referencing constant that are always forbidden will raise a ForbiddenCommand error" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, always: ["SomeClass"]
         SomeClass.some_method
       RUBY
@@ -10,7 +10,7 @@ class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
   end
 
   test "validate referencing namespaced constants that are always forbidden will raise a ForbiddenCommand error" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, always: ["Some::Base::Class"]
         puts Some::Base::Class.config
       RUBY
@@ -18,7 +18,7 @@ class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
   end
 
   test "validate referencing a namespaced constant where the parent constant is banned" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, always: ["Some"]
         puts Some::Base::Class.config
       RUBY
@@ -26,7 +26,7 @@ class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
   end
 
   test "validate constants with leading ::" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, always: ["Some"]
         puts ::Some::Base::Class.config
       RUBY
@@ -38,7 +38,7 @@ class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
       SomeClass.some_method
     RUBY
 
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, protected: ["SomeClass"], shield: OpenStruct.new(protected_mode?: true)
         SomeClass.some_method
       RUBY

--- a/test/command_validator/forbidden_constant_reference_validation_test.rb
+++ b/test/command_validator/forbidden_constant_reference_validation_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
-  test "validate referencing constant that are always forbidden will raise a ForbiddenCommand error" do
+  test "validate referencing constant that are always forbidden will raise a ForbiddenCommandAttempted error" do
     assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, always: ["SomeClass"]
         SomeClass.some_method
@@ -9,7 +9,7 @@ class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
     end
   end
 
-  test "validate referencing namespaced constants that are always forbidden will raise a ForbiddenCommand error" do
+  test "validate referencing namespaced constants that are always forbidden will raise a ForbiddenCommandAttempted error" do
     assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, always: ["Some::Base::Class"]
         puts Some::Base::Class.config
@@ -33,7 +33,7 @@ class ForbiddenConstantReferenceValidationTest < ActiveSupport::TestCase
     end
   end
 
-  test "validate referencing constant that are forbidden in protected mode will raise a ForbiddenCommand error only in protected mode" do
+  test "validate referencing constant that are forbidden in protected mode will raise a ForbiddenCommandAttempted error only in protected mode" do
     run_validation <<~RUBY, protected: ["SomeClass"], shield: OpenStruct.new(protected_mode?: false)
       SomeClass.some_method
     RUBY

--- a/test/command_validator/forbidden_reopening_validation_test.rb
+++ b/test/command_validator/forbidden_reopening_validation_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ForbiddenReopeningValidationTest < ActiveSupport::TestCase
   test "validate reopening classes that are always forbidden will raise a ForbiddenCommand error" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, ["SomeClass"]
         class SomeClass
         end
@@ -11,7 +11,7 @@ class ForbiddenReopeningValidationTest < ActiveSupport::TestCase
   end
 
   test "validate reopening modules that are always forbidden will raise a ForbiddenCommand error" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, ["SomeModule"]
         module SomeModule
         end
@@ -20,7 +20,7 @@ class ForbiddenReopeningValidationTest < ActiveSupport::TestCase
   end
 
   test "validate reopening namespaced classes" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, ["Some::Base::Class"]
         class Some::Base::Class
         end
@@ -29,7 +29,7 @@ class ForbiddenReopeningValidationTest < ActiveSupport::TestCase
   end
 
   test "validate reopening namespaced classes when the parent module is banned" do
-    assert_raise Console1984::Errors::ForbiddenCommand do
+    assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, ["Some"]
         module Some::Base::Class
         end

--- a/test/command_validator/forbidden_reopening_validation_test.rb
+++ b/test/command_validator/forbidden_reopening_validation_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class ForbiddenReopeningValidationTest < ActiveSupport::TestCase
-  test "validate reopening classes that are always forbidden will raise a ForbiddenCommand error" do
+  test "validate reopening classes that are always forbidden will raise a ForbiddenCommandAttempted error" do
     assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, ["SomeClass"]
         class SomeClass
@@ -10,7 +10,7 @@ class ForbiddenReopeningValidationTest < ActiveSupport::TestCase
     end
   end
 
-  test "validate reopening modules that are always forbidden will raise a ForbiddenCommand error" do
+  test "validate reopening modules that are always forbidden will raise a ForbiddenCommandAttempted error" do
     assert_raise Console1984::Errors::ForbiddenCommandAttempted do
       run_validation <<~RUBY, ["SomeModule"]
         module SomeModule

--- a/test/command_validator/suspicious_terms_validation_test.rb
+++ b/test/command_validator/suspicious_terms_validation_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SuspicipusTermsValidationTest < ActiveSupport::TestCase
   test "raises a SuspiciousCommand error when a suspicious term appears in the command" do
-    assert_raise Console1984::Errors::SuspiciousCommand do
+    assert_raise Console1984::Errors::SuspiciousCommandAttempted do
       run_validation <<~RUBY, ["woah"]
         foo = "woah"
       RUBY

--- a/test/support/supervised_test_console.rb
+++ b/test/support/supervised_test_console.rb
@@ -7,6 +7,8 @@ class SupervisedTestConsole
     @string_io = StringIO.new
     ENV["CONSOLE_USER"] = user
 
+    @context = Context.new
+    IRB.stubs(CurrentContext: @context)
     start_supervisor(reason)
   end
 
@@ -56,6 +58,16 @@ class SupervisedTestConsole
 
       def initialize(supervisor)
         @supervisor = supervisor
+      end
+    end
+
+    class Context
+      def exit
+        @exited = true
+      end
+
+      def exited?
+        @exited
       end
     end
 end


### PR DESCRIPTION
#26 and #27 introduced several mechanisms based on detecting tampering attempts statically *before* commands were executed. This PR adds a new check against reopening forbidden classes. If a forbidden reopening materializes, it will log the command and force exiting from IRB.

Take this example:

```ruby
def my_constant
  ActiveRecord
end

class my_constant::Base
  def fake_save!(*args)
    puts "ActiveRecord::Base#save! overridden!"
  end
end
```

This code would skip our static analysis. We can detect it now because we let the code run and we validate that no new methods were added to the class. Because the code executes, the damage is done, so we log the attempt (which could be prevented by the command) and, in any case, we exit from IRB.
