### PR TITLE
Fix flagging `String#constantize` invocations as suspicious

### DIFF
--- a/lib/console1984/command_executor.rb
+++ b/lib/console1984/command_executor.rb
@@ -10,6 +10,7 @@ class Console1984::CommandExecutor
   include Console1984::Freezeable
 
   delegate :username_resolver, :session_logger, :shield, to: Console1984
+  attr_reader :last_suspicious_command_error
 
   # Logs and validates +commands+, and executes the passed block in a protected environment.
   #
@@ -19,14 +20,14 @@ class Console1984::CommandExecutor
     run_as_system { session_logger.before_executing commands }
     validate_command commands
     execute_in_protected_mode(&block)
-  rescue Console1984::Errors::ForbiddenCommandAttempted, FrozenError
-    flag_suspicious(commands)
-  rescue Console1984::Errors::SuspiciousCommandAttempted
-    flag_suspicious(commands)
+  rescue Console1984::Errors::ForbiddenCommandAttempted, FrozenError => error
+    flag_suspicious(commands, error: error)
+  rescue Console1984::Errors::SuspiciousCommandAttempted => error
+    flag_suspicious(commands, error: error)
     execute_in_protected_mode(&block)
-  rescue Console1984::Errors::ForbiddenCommandExecuted
+  rescue Console1984::Errors::ForbiddenCommandExecuted => error
     # We detected that a forbidden command was executed. We exit IRB right away.
-    flag_suspicious(commands)
+    flag_suspicious(commands, error: error)
     Console1984.supervisor.exit_irb
   ensure
     run_as_system { session_logger.after_executing commands }
@@ -86,9 +87,10 @@ class Console1984::CommandExecutor
       Console1984::CommandValidator.from_config(Console1984.protections_config.validations)
     end
 
-    def flag_suspicious(commands)
+    def flag_suspicious(commands, error: nil)
       puts "Forbidden command attempted: #{commands.join("\n")}"
       run_as_system { session_logger.suspicious_commands_attempted commands }
+      @last_suspicious_command_error = error
       nil
     end
 

--- a/lib/console1984/command_executor.rb
+++ b/lib/console1984/command_executor.rb
@@ -71,11 +71,7 @@ class Console1984::CommandExecutor
   end
 
   def from_irb?(backtrace)
-    executing_user_command? && backtrace.find do |line|
-      line_from_irb = line =~ /^[^\/]/
-      break if !(line =~ /console1984\/lib/ || line_from_irb)
-      line_from_irb
-    end
+    executing_user_command? && backtrace.first.to_s =~ /^[^\/]/
   end
 
   private

--- a/lib/console1984/ext/core/object.rb
+++ b/lib/console1984/ext/core/object.rb
@@ -16,7 +16,7 @@ module Console1984::Ext::Core::Object
 
   class_methods do
     def const_get(*arguments)
-      if Console1984.command_executor.executing_user_command?
+      if Console1984.command_executor.from_irb?(caller)
         begin
           # To validate if it's an invalid constant, we try to declare a class with it.
           # We essentially leverage Console1984::CommandValidator::ForbiddenReopeningValidation here:

--- a/lib/console1984/ext/core/string.rb
+++ b/lib/console1984/ext/core/string.rb
@@ -1,0 +1,24 @@
+# Prevents loading forbidden classes dynamically.
+#
+# See extension to +Console1984::Ext::Core::Object#const_get+.
+module Console1984::Ext::Core::String
+  extend ActiveSupport::Concern
+
+  include Console1984::Freezeable
+  self.prevent_instance_data_manipulation_after_freezing = false
+
+  def constantize
+    if Console1984.command_executor.from_irb?(caller)
+      begin
+        Console1984.command_executor.validate_command("class #{self}; end")
+        super
+      rescue Console1984::Errors::ForbiddenCommandAttempted
+        raise
+      rescue StandardError
+        super
+      end
+    else
+      super
+    end
+  end
+end

--- a/lib/console1984/ext/irb/commands.rb
+++ b/lib/console1984/ext/irb/commands.rb
@@ -13,4 +13,13 @@ module Console1984::Ext::Irb::Commands
   def encrypt!
     shield.enable_protected_mode
   end
+
+  # This returns the last error that prevented a command execution in the console
+  # or nil if there isn't any.
+  #
+  # This is meant for internal usage when debugging legit commands that are wrongly
+  # prevented.
+  def _console_last_suspicious_command_error
+    Console1984.command_executor.last_suspicious_command_error
+  end
 end

--- a/lib/console1984/shield.rb
+++ b/lib/console1984/shield.rb
@@ -40,6 +40,7 @@ class Console1984::Shield
     def extend_core_ruby
       Object.prepend Console1984::Ext::Core::Object
       Module.prepend Console1984::Ext::Core::Module
+      String.prepend Console1984::Ext::Core::String
     end
 
     def extend_sockets


### PR DESCRIPTION
This prevents flagging commands that end up invoking `String#constantize` as suspicious (unless they originate directly in the IRB session). It also adds a mechanism to debug errors to see which triggers such errors.