### PR TITLE
Ruby 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
       - name: Setup test database
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        ruby-version: [2.7.2, 3.0.2]
         database: [sqlite, postgres, mysql]
     services:
       redis:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GIT
 PATH
   remote: .
   specs:
-    console1984 (0.1.18)
+    console1984 (0.1.19)
       colorize
       parser
 

--- a/console1984.gemspec
+++ b/console1984.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'http://github.com/basecamp/console1984'
   spec.summary     = 'Your Rails console, 1984 style'
   spec.license     = 'MIT'
+  spec.required_ruby_version = '>= 2.7.0'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.

--- a/lib/console1984/ext/socket/tcp_socket.rb
+++ b/lib/console1984/ext/socket/tcp_socket.rb
@@ -2,13 +2,13 @@
 module Console1984::Ext::Socket::TcpSocket
   include Console1984::Freezeable
 
-  def write(*args)
+  def write(...)
     protecting do
       super
     end
   end
 
-  def write_nonblock(*args)
+  def write_nonblock(...)
     protecting do
       super
     end

--- a/lib/console1984/version.rb
+++ b/lib/console1984/version.rb
@@ -1,3 +1,3 @@
 module Console1984
-  VERSION = '0.1.18'
+  VERSION = '0.1.19'
 end

--- a/test/ext/socket/tcp_socket_test.rb
+++ b/test/ext/socket/tcp_socket_test.rb
@@ -4,7 +4,7 @@ class TCPSocketTest < ActiveSupport::TestCase
   test "doesn't raise when forwarding kwargs" do
     assert_nothing_raised do
       socket = TCPSocket.new("localhost", 6379)
-      socket.write_nonblock "forbidden request!", exception: false
+      socket.write_nonblock "content", exception: false
     end
   end
 end

--- a/test/ext/socket/tcp_socket_test.rb
+++ b/test/ext/socket/tcp_socket_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class TCPSocketTest < ActiveSupport::TestCase
   test "doesn't raise when forwarding kwargs" do
     assert_nothing_raised do
-      socket = TCPSocket.new 'localhost', 6379
+      socket = TCPSocket.new("localhost", 6379)
       socket.write_nonblock "forbidden request!", exception: false
     end
   end

--- a/test/ext/socket/tcp_socket_test.rb
+++ b/test/ext/socket/tcp_socket_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class TCPSocketTest < ActiveSupport::TestCase
+  test "doesn't raise when forwarding kwargs" do
+    assert_nothing_raised do
+      socket = TCPSocket.new 'localhost', 6379
+      socket.write_nonblock "forbidden request!", exception: false
+    end
+  end
+end


### PR DESCRIPTION
Add support for Ruby 3.

When https://github.com/redis/redis-rb/blob/bc7ed4bd9c6f30ea55c40f8df71f25c2b8670953/lib/redis/connection/ruby.rb#L77 calls #write_nonblock it passes a keyword argument, `exception: false`.

The behaviour of splatting arguments [changed in Ruby 3](https://makandracards.com/makandra/496481-changes-to-positional-and-keyword-args-in-ruby-3-0).

I added a test case to cover this, which passed on Ruby 2.7, but failed on Ruby 3.

Then I added a fix using [argument forwarding](https://blog.saeloun.com/2019/12/04/ruby-2-7-adds-new-operator-for-arguments-forwarding.html), new in Ruby 2.7.

I also updated the CI config to test on Ruby 3.