### PR TITLE
Fix: error when referencing thread attribute after Rails upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GIT
 PATH
   remote: .
   specs:
-    console1984 (0.1.19)
+    console1984 (0.1.20)
       colorize
       parser
 

--- a/lib/console1984/shield/modes/protected.rb
+++ b/lib/console1984/shield/modes/protected.rb
@@ -6,6 +6,11 @@ class Console1984::Shield::Modes::Protected
 
   thread_mattr_accessor :currently_protected_urls, default: []
 
+  # Materialize the thread attribute before freezing the class. +thread_mattr_accessor+ attributes rely on
+  # setting a class variable the first time they are referenced, and that will fail in frozen classes
+  # like this one.
+  currently_protected_urls
+
   def execute(&block)
     protecting(&block)
   end

--- a/lib/console1984/version.rb
+++ b/lib/console1984/version.rb
@@ -1,3 +1,3 @@
 module Console1984
-  VERSION = '0.1.19'
+  VERSION = '0.1.20'
 end


### PR DESCRIPTION
Thread attributes will now declare a class variable on the fly when referenced. This causes a problem if the class is frozen. 

The patch is just referencing the attribute so that it gets materialized before having the class frozen.

CC @basecamp/sip 
