### PR TITLE
Avoid creating redundant indexes in sessions and commands tables

### DIFF
--- a/db/migrate/20210517203931_create_console1984_tables.rb
+++ b/db/migrate/20210517203931_create_console1984_tables.rb
@@ -2,7 +2,7 @@ class CreateConsole1984Tables < ActiveRecord::Migration[7.0]
   def change
     create_table :console1984_sessions do |t|
       t.text :reason
-      t.references :user, null: false
+      t.references :user, null: false, index: false
       t.timestamps
 
       t.index :created_at
@@ -19,7 +19,7 @@ class CreateConsole1984Tables < ActiveRecord::Migration[7.0]
     create_table :console1984_commands do |t|
       t.text :statements
       t.references :sensitive_access
-      t.references :session, null: false
+      t.references :session, null: false, index: false
       t.timestamps
 
       t.index [ :session_id, :created_at, :sensitive_access_id ], name: "on_session_and_sensitive_chronologically"


### PR DESCRIPTION
This is a super tiny change. I was reviewing a DB schema and noticed a couple of redundant indexes in the `console1984_sessions` and `console1984_commands` tables. They're created via `references`, and are redundant because other indexes that have them as prefix are also added. 

I believe this change will prevent these indexes from being created. 
