### PR TITLE
Respect the user's preference for how to case their username

### DIFF
--- a/lib/console1984/username/env_resolver.rb
+++ b/lib/console1984/username/env_resolver.rb
@@ -13,6 +13,6 @@ class Console1984::Username::EnvResolver
 
   private
     def username
-      @username ||= ENV[@key]&.humanize
+      @username ||= ENV[@key]
     end
 end


### PR DESCRIPTION
The user knows how their own name is spelled/cased; we should respect that.