### PR TITLE
Forbid reopening of ApplicationRecord

### DIFF
--- a/config/protections.yml
+++ b/config/protections.yml
@@ -1,6 +1,7 @@
 validations:
   forbidden_reopening:
     - ActiveRecord
+    - ApplicationRecord
     - Console1984
     - PG
     - Mysql2

--- a/test/tampering_cases/flagged/application_record/override_application_record_base.rb
+++ b/test/tampering_cases/flagged/application_record/override_application_record_base.rb
@@ -1,0 +1,5 @@
+class ApplicationRecord
+  def save!(*args)
+    puts "ApplicationRecord#save! overridden!"
+  end
+end

--- a/test/tampering_cases/flagged/application_record/override_application_record_base_using_constant_alias.rb
+++ b/test/tampering_cases/flagged/application_record/override_application_record_base_using_constant_alias.rb
@@ -1,0 +1,7 @@
+MyAlias = ApplicationRecord
+
+class MyAlias
+  def save!(*args)
+    puts "ApplicationRecord#save! overridden!"
+  end
+end

--- a/test/tampering_cases/flagged/application_record/override_application_record_base_with_class_eval.rb
+++ b/test/tampering_cases/flagged/application_record/override_application_record_base_with_class_eval.rb
@@ -1,0 +1,5 @@
+ApplicationRecord.class_eval do
+  def save!(*args)
+    puts "ApplicationRecord#save! overridden!"
+  end
+end

--- a/test/tampering_cases/flagged/application_record/prevent_accessing_application_record_class_via_const_get.rb
+++ b/test/tampering_cases/flagged/application_record/prevent_accessing_application_record_class_via_const_get.rb
@@ -1,0 +1,1 @@
+"ApplicationRecord".constantize

--- a/test/tampering_cases/flagged/application_record/prevent_using_connection_to_delete_stuff.rb
+++ b/test/tampering_cases/flagged/application_record/prevent_using_connection_to_delete_stuff.rb
@@ -1,0 +1,1 @@
+ApplicationRecord.connection.execute "delete from console1984_sessions"


### PR DESCRIPTION
Hey Jorge, I was playing around with `console1984` and `audits1984` to see how things work there at 37signals ([just in case](https://github.com/search?q=bc86af65417b7b371a641e77a7e45c9d1a20842d&type=issues), you know... :roll_eyes:)

I haven't checked out the entire codebase, but when I saw that the `Base` model, and thus all other models, are inheriting from `ApplicationRecord` I was curious to see if that's a weak spot, and it seems it is.

You can run the following in a console:
```ruby
class ApplicationRecord
  def save!(*args)
    puts "Using the cloak of invisibility"
  end
end
```
And all following commands won't be tracked anymore.

This adds the `ApplicationRecord` to the forbidden list :wink: 

A couple of tests are already covered by other rules (`class_eval` and `console1984`) but maybe it's worth keeping them around.