### PR TITLE
Check the connection before logging statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ test/dummy/db/*.sqlite3-*
 test/dummy/log/*.log
 test/dummy/storage/
 test/dummy/tmp/
-/.rubocop-https---raw-githubusercontent-com-rails-rails-master--rubocop-yml
+/.rubocop-https---raw-githubusercontent-com-rails-rails-*--rubocop-yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-inherit_from: https://raw.githubusercontent.com/rails/rails/master/.rubocop.yml
+inherit_from: https://raw.githubusercontent.com/rails/rails/v7.0.4/.rubocop.yml
 
 Performance:
   Exclude:

--- a/lib/console1984/sessions_logger/database.rb
+++ b/lib/console1984/sessions_logger/database.rb
@@ -5,8 +5,7 @@ class Console1984::SessionsLogger::Database
   attr_reader :current_session, :current_sensitive_access
 
   def start_session(username, reason)
-    silence_logging do
-      ensure_connected
+    silence_logging_and_ensure_connected do
       user = Console1984::User.find_or_create_by!(username: username)
       @current_session = user.sessions.create!(reason: reason)
     end
@@ -18,8 +17,7 @@ class Console1984::SessionsLogger::Database
   end
 
   def start_sensitive_access(justification)
-    silence_logging do
-      ensure_connected
+    silence_logging_and_ensure_connected do
       @current_sensitive_access = current_session.sensitive_accesses.create! justification: justification
     end
   end
@@ -29,8 +27,7 @@ class Console1984::SessionsLogger::Database
   end
 
   def before_executing(statements)
-    silence_logging do
-      ensure_connected
+    silence_logging_and_ensure_connected do
       @before_commands_count = @current_session.commands.count
       record_statements statements
     end
@@ -40,8 +37,7 @@ class Console1984::SessionsLogger::Database
   end
 
   def suspicious_commands_attempted(statements)
-    silence_logging do
-      ensure_connected
+    silence_logging_and_ensure_connected do
       sensitive_access = start_sensitive_access "Suspicious commands attempted"
       Console1984::Command.last.update! sensitive_access: sensitive_access
     end
@@ -52,17 +48,20 @@ class Console1984::SessionsLogger::Database
       @current_session.commands.create! statements: Array(statements).join("\n"), sensitive_access: current_sensitive_access
     end
 
-    def silence_logging(&block)
+    def silence_logging_and_ensure_connected(&block)
       if Console1984.debug
-        block.call
+        ensure_connected(&block)
       else
         Console1984::IncinerationJob.logger.silence do
-          Console1984::Base.logger.silence(&block)
+          Console1984::Base.logger.silence do
+            ensure_connected(&block)
+          end
         end
       end
     end
 
-    def ensure_connected
+    def ensure_connected(&block)
       Console1984::Command.connection.reconnect! unless Console1984::Command.connection.active?
+      block.call
     end
 end


### PR DESCRIPTION
If the database connection has been lost you can't reconnect because console1984 raises an error when it tries to record the statement.

Let's check the connection first and reconnect if it is not active.

cc @jorgemanrubia 