### PR TITLE
Change colorize gem to rainbow, reason: License

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ PATH
   remote: .
   specs:
     console1984 (0.1.26)
+      colorize
       parser
-      rainbow
 
 GEM
   remote: https://rubygems.org/
@@ -83,6 +83,7 @@ GEM
     ast (2.4.2)
     benchmark-ips (2.9.2)
     builder (3.2.4)
+    colorize (0.8.1)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ PATH
   remote: .
   specs:
     console1984 (0.1.26)
-      colorize
       parser
+      rainbow
 
 GEM
   remote: https://rubygems.org/
@@ -83,7 +83,6 @@ GEM
     ast (2.4.2)
     benchmark-ips (2.9.2)
     builder (3.2.4)
-    colorize (0.8.1)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,8 +11,8 @@ PATH
   remote: .
   specs:
     console1984 (0.1.26)
-      colorize
       parser
+      rainbow
 
 GEM
   remote: https://rubygems.org/
@@ -83,7 +83,6 @@ GEM
     ast (2.4.2)
     benchmark-ips (2.9.2)
     builder (3.2.4)
-    colorize (0.8.1)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)
@@ -99,20 +98,18 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.1)
     minitest (5.15.0)
     mocha (1.13.0)
-    mysql2 (0.5.3)
+    mysql2 (0.5.4)
     nio4r (2.5.8)
-    nokogiri (1.13.6-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.6-x86_64-linux)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
-    pg (1.2.3)
+    pg (1.4.5)
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -183,6 +180,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 

--- a/console1984.gemspec
+++ b/console1984.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob(['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md', 'test/fixtures/**/*'], File::FNM_DOTMATCH)
 
-  spec.add_dependency 'colorize'
+  spec.add_dependency 'rainbow'
   spec.add_dependency 'parser'
 
   spec.add_development_dependency 'rails', '>= 7.0'

--- a/console1984.gemspec
+++ b/console1984.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob(['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md', 'test/fixtures/**/*'], File::FNM_DOTMATCH)
 
-  spec.add_dependency 'rainbow'
+  spec.add_dependency 'colorize'
   spec.add_dependency 'parser'
 
   spec.add_development_dependency 'rails', '>= 7.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,4 @@ services:
     volumes:
       - db:/var/lib/postgres
     ports: [ "127.0.0.1:55432:5432" ]
-  mysql:
-    image: percona:5.7.22
-    environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-    volumes:
-      - db:/var/lib/mysql
-    ports: [ "127.0.0.1:33306:3306" ]
 

--- a/lib/console1984/input_output.rb
+++ b/lib/console1984/input_output.rb
@@ -20,17 +20,17 @@ module Console1984::InputOutput
 
       Commands:
 
-      #{COMMANDS.collect { |command, help_line| "* #{ColorizedString.new(command.to_s).light_blue}: #{help_line}" }.join("\n")}
+      #{COMMANDS.collect { |command, help_line| "* #{Rainbow(command.to_s).light_blue}: #{help_line}" }.join("\n")}
 
       TXT
     end
 
     def show_warning(message)
-      puts ColorizedString.new("\n#{message}\n").yellow
+      puts Rainbow("\n#{message}\n").yellow
     end
 
     def ask_for_value(message)
-      puts ColorizedString.new("#{message}").green
+      puts Rainbow("#{message}").green
       reason = $stdin.gets.strip until reason.present?
       reason
     end

--- a/lib/console1984/input_output.rb
+++ b/lib/console1984/input_output.rb
@@ -20,7 +20,7 @@ module Console1984::InputOutput
 
       Commands:
 
-      #{COMMANDS.collect { |command, help_line| "* #{Rainbow(command.to_s).light_blue}: #{help_line}" }.join("\n")}
+      #{COMMANDS.collect { |command, help_line| "* #{Rainbow(command.to_s).blue}: #{help_line}" }.join("\n")}
 
       TXT
     end

--- a/lib/console1984/supervisor.rb
+++ b/lib/console1984/supervisor.rb
@@ -44,7 +44,7 @@ class Console1984::Supervisor
       Kernel.silence_warnings do
         require 'parser/current'
       end
-      require 'colorized_string'
+      require 'rainbow'
 
       # Explicit lazy loading because it depends on +parser+, which we want to only load
       # in console sessions.


### PR DESCRIPTION
colorize uses GLP-2
The GPL licenses include a strong copyleft clause, which could cause to the user to be required to publish the source code.