### PR TITLE
Add configuration option for base record class

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ These config options are namespaced in `config.console1984`:
 | `incinerate`                                | Whether incinerate sessions automatically after a period of time or not. Default to `true`.                                                                                                                            |
 | `incinerate_after`                          | The period to keep sessions around before incinerate them. Default `30.days`.                                                                                                                                          |
 | `incineration_queue`                        | The name of the queue for session incineration jobs. Default `console1984_incineration`.                                                                                                                               |
+| `base_record_class`                         | The host application base class that will be the parent of `console1984` records. By default it's `::ApplicationRecord`. |
 
 ### SSH Config
 

--- a/app/models/console1984/base.rb
+++ b/app/models/console1984/base.rb
@@ -1,5 +1,5 @@
 module Console1984
-  class Base < ApplicationRecord
+  class Base < Console1984.config.base_record_class.constantize
     self.abstract_class = true
   end
 end

--- a/lib/console1984/config.rb
+++ b/lib/console1984/config.rb
@@ -12,6 +12,7 @@ class Console1984::Config
     production_data_warning enter_unprotected_encryption_mode_warning enter_protected_mode_warning
     incinerate incinerate_after incineration_queue
     protections_config
+    base_record_class
     debug test_mode
   ]
 
@@ -55,6 +56,8 @@ class Console1984::Config
       self.incinerate_after = 30.days
       self.incineration_queue = "console1984_incineration"
       self.ask_for_username_if_empty = false
+
+      self.base_record_class = "::ApplicationRecord"
 
       self.debug = false
       self.test_mode = false


### PR DESCRIPTION
Add a `base_record_class` configuration option to configure the base record class for Console1984's records.

The default is `::ApplicationRecord` so this is a non-breaking change for current users.

cc @jorgemanrubia
