### PR TITLE
Prevent errors from leaking encrypted information

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   mysql:
-    image: percona:5.7.22
+    image: mariadb:latest
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:

--- a/lib/console1984/command_executor.rb
+++ b/lib/console1984/command_executor.rb
@@ -29,6 +29,8 @@ class Console1984::CommandExecutor
     # We detected that a forbidden command was executed. We exit IRB right away.
     flag_suspicious(commands, error: error)
     Console1984.supervisor.exit_irb
+  rescue => error
+    raise encrypting_error(error)
   ensure
     run_as_system { session_logger.after_executing commands }
   end
@@ -96,5 +98,17 @@ class Console1984::CommandExecutor
       block.call
     ensure
       @executing_user_command = original_value
+    end
+
+    def encrypting_error(error)
+      def error.inspect
+        Console1984.command_executor.execute_in_protected_mode { super }
+      end
+
+      def error.to_s
+        Console1984.command_executor.execute_in_protected_mode { super }
+      end
+
+      error
     end
 end

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -72,6 +72,22 @@ class EncryptionTest < ActiveSupport::TestCase
     assert_equal "Other name", @person.reload.name
   end
 
+  test "does not reveal attributes when raising errors" do
+    error = nil
+
+    begin
+      @console.execute <<~RUBY
+        Person.find(#{@person.id}).method_that_does_not_exist
+      RUBY
+    rescue => e
+      error = e
+    end
+
+    assert_not_nil error
+    assert_not_includes error.inspect.remove(@person.email), @person.name
+    assert_not_includes error.to_s.remove(@person.email), @person.name
+  end
+
   private
     def execute_decrypt_and_enter_reason
       type_when_prompted "I need to fix encoding issue with Message 123456" do


### PR DESCRIPTION
Errors will abandon the protected execution content and they can carry unencrypted information that will be rendered when showing the error.

Fixes  https://github.com/basecamp/console1984/issues/98
