### PR TITLE
Incompatability with `symbol-fstring`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ gemspec
 gem 'rubyzip'
 
 gem 'activeresource', git: 'https://github.com/basecamp/activeresource.git'
+
+gem 'symbol-fstring', require: 'fstring/all'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
     rubyzip (2.3.2)
     sqlite3 (1.6.3-arm64-darwin)
     sqlite3 (1.6.3-x86_64-linux)
+    symbol-fstring (1.0.2)
     thor (1.2.2)
     timeout (0.4.0)
     tzinfo (2.0.6)
@@ -210,6 +211,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
@@ -227,6 +229,7 @@ DEPENDENCIES
   rubocop-rails
   rubyzip
   sqlite3
+  symbol-fstring
 
 BUNDLED WITH
    2.3.22

--- a/test/auditing_test.rb
+++ b/test/auditing_test.rb
@@ -42,6 +42,12 @@ class AuditingTest < ActiveSupport::TestCase
     assert_not Console1984::Command.last.sensitive?
   end
 
+  test "commands in protected mode on namespaced objects are not flagged as sensitive" do
+    @console.execute "puts ::Namespaced::Thing.last.name"
+    
+    assert_not Console1984::Command.last.sensitive?, @console.output
+  end
+
   test "commands in unprotected mode are justified and flagged as sensitive" do
     assert_difference -> { Console1984::SensitiveAccess.count }, +1 do
       type_when_prompted "I need to fix encoding issue with Message 123456" do

--- a/test/dummy/app/models/namespaced/thing.rb
+++ b/test/dummy/app/models/namespaced/thing.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Namespaced::Thing < ApplicationRecord
+  self.table_name = "people"
+  encrypts :name
+end


### PR DESCRIPTION
An incompability exists with https://github.com/Shopify/symbol-fstring. I'm not sure if the bug is in this gem or that one, but it's easier to make a test case here and I *think* the bug is here.

The attached test fails, but it passes if you remove the extra gem. It fails because with the gem, [`const_name` is `frozen?` here](https://github.com/basecamp/console1984/blob/f0f2efd489b94be8bbc9bcfb6bff778be3885d78/lib/console1984/command_validator/.command_parser.rb#L43). As a result [this line raises a `FrozenError`](https://github.com/basecamp/console1984/blob/f0f2efd489b94be8bbc9bcfb6bff778be3885d78/lib/console1984/command_validator/.command_parser.rb#L53), and that gets handled [here](https://github.com/basecamp/console1984/blob/f0f2efd489b94be8bbc9bcfb6bff778be3885d78/lib/console1984/command_executor.rb#L23..L24).

This is only an issue when loading a namespaced constant.