### PR TITLE
Add Rails as runtime dependency and require 7.0+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,4 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # development dependencies will be added by default to the :development group.
 gemspec
 
-# Declare any dependencies that are still in development here instead of in
-# your gemspec. These might include edge Rails or gems from your path or
-# Git. Remember to move these dependencies to your gemspec before releasing
-# your gem to rubygems.org.
-
-# To use a debugger
-# gem 'byebug', group: [:development, :test]
-
-gem 'rubyzip'
-
 gem 'activeresource', git: 'https://github.com/basecamp/activeresource.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ PATH
   specs:
     console1984 (0.1.31)
       parser
+      rails (>= 7.0)
       rainbow
 
 GEM
@@ -91,15 +92,15 @@ GEM
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
-    date (3.3.3)
+    date (3.3.4)
     erubi (1.12.0)
-    globalid (1.1.0)
-      activesupport (>= 5.0)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
-    loofah (2.21.3)
+    loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -107,26 +108,26 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.2)
+    marcel (1.0.4)
     method_source (1.0.0)
-    mini_mime (1.1.2)
+    mini_mime (1.1.5)
     minitest (5.18.1)
     mocha (2.0.4)
       ruby2_keywords (>= 0.0.5)
     mysql2 (0.5.5)
-    net-imap (0.3.6)
+    net-imap (0.4.10)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
-    net-smtp (0.3.3)
+    net-smtp (0.4.0.1)
       net-protocol
-    nio4r (2.5.9)
-    nokogiri (1.15.3-arm64-darwin)
+    nio4r (2.7.0)
+    nokogiri (1.16.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-linux)
+    nokogiri (1.16.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.3)
@@ -151,7 +152,7 @@ GEM
       activesupport (= 7.0.6)
       bundler (>= 1.15.0)
       railties (= 7.0.6)
-    rails-dom-testing (2.1.1)
+    rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -166,7 +167,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
-    rake (13.0.6)
+    rake (13.1.0)
     regexp_parser (2.8.1)
     rexml (3.2.5)
     rubocop (1.54.1)
@@ -198,15 +199,15 @@ GEM
     rubyzip (2.3.2)
     sqlite3 (1.6.3-arm64-darwin)
     sqlite3 (1.6.3-x86_64-linux)
-    thor (1.2.2)
-    timeout (0.4.0)
+    thor (1.3.1)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    websocket-driver (0.7.5)
+    websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.8)
+    zeitwerk (2.6.13)
 
 PLATFORMS
   arm64-darwin-21
@@ -219,7 +220,6 @@ DEPENDENCIES
   mocha
   mysql2
   pg
-  rails (>= 7.0)
   rubocop (>= 1.18.4)
   rubocop-minitest
   rubocop-packaging
@@ -229,4 +229,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.3.22
+   2.3.25

--- a/console1984.gemspec
+++ b/console1984.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rainbow'
   spec.add_dependency 'parser'
+  spec.add_dependency 'rails', '>= 7.0'
 
-  spec.add_development_dependency 'rails', '>= 7.0'
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'rubocop', '>= 1.18.4'
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'pg'
   spec.add_development_dependency 'mysql2'
+  spec.add_development_dependency 'rubyzip'
 end

--- a/test/incineration_test.rb
+++ b/test/incineration_test.rb
@@ -13,12 +13,12 @@ class IncinerationTest < ActiveSupport::TestCase
       console.execute "2+2"
     end
 
-    travel 30.days
-
-    assert_difference -> { Console1984::Session.count }, -1 do
-      assert_difference -> { Console1984::Command.count }, -3 do
-        assert_difference -> { Console1984::SensitiveAccess.count }, -1 do
-          perform_enqueued_jobs only: Console1984::IncinerationJob
+    travel_to 30.days.from_now.utc do
+      assert_difference -> { Console1984::Session.count }, -1 do
+        assert_difference -> { Console1984::Command.count }, -3 do
+          assert_difference -> { Console1984::SensitiveAccess.count }, -1 do
+            perform_enqueued_jobs only: Console1984::IncinerationJob
+          end
         end
       end
     end
@@ -43,10 +43,10 @@ class IncinerationTest < ActiveSupport::TestCase
       session.incinerate
     end
 
-    travel 30.days
-
-    assert_nothing_raised do
-      session.incinerate
+    travel_to 30.days.from_now.utc do
+      assert_nothing_raised do
+        session.incinerate
+      end
     end
   end
 end


### PR DESCRIPTION
Related to https://github.com/basecamp/audits1984/pull/55#issuecomment-2003374011

This also fixes a small issue with incineration tests when they're run in a local environment where the timezone is set to something else than UTC. 