### PR TITLE
Check if Redis' socket classes are defined before using them

### DIFF
--- a/lib/console1984/shield.rb
+++ b/lib/console1984/shield.rb
@@ -47,8 +47,12 @@ class Console1984::Shield
       socket_classes = [TCPSocket, OpenSSL::SSL::SSLSocket]
       OpenSSL::SSL::SSLSocket.include(SSLSocketRemoteAddress)
 
-      if defined?(Redis::Connection)
-        socket_classes.push(*[Redis::Connection::TCPSocket, Redis::Connection::SSLSocket])
+      if defined?(Redis::Connection::TCPSocket)
+        socket_classes.push(Redis::Connection::TCPSocket)
+      end
+
+      if defined?(Redis::Connection::TCPSocket)
+        socket_classes.push(Redis::Connection::SSLSocket)
       end
 
       socket_classes.compact.each do |socket_klass|


### PR DESCRIPTION
Some of these, such as `Redis::Connection::TCPSocket`, have been removed in `redis-rb` 5.0.0. 