### PR TITLE
Support for irb 1.13+

### DIFF
--- a/lib/console1984/ext/irb/context.rb
+++ b/lib/console1984/ext/irb/context.rb
@@ -16,10 +16,10 @@ module Console1984::Ext::Irb::Context
     # irb  < 1.13 passes String as parameter
     # irb >= 1.13 passes IRB::Statement instead and method #code contains the actual code
     code = if defined?(IRB::Statement) && line_or_statement.kind_of?(IRB::Statement)
-             line_or_statement.code
-           else
-             line_or_statement
-           end
+      line_or_statement.code
+    else
+      line_or_statement
+    end
 
     Console1984.command_executor.execute(Array(code)) do
       super

--- a/lib/console1984/ext/irb/context.rb
+++ b/lib/console1984/ext/irb/context.rb
@@ -12,8 +12,16 @@ module Console1984::Ext::Irb::Context
   end
 
   #
-  def evaluate(line, ...)
-    Console1984.command_executor.execute(Array(line)) do
+  def evaluate(line_or_statement, ...)
+    # irb  < 1.13 passes String as parameter
+    # irb >= 1.13 passes IRB::Statement instead and method #code contains the actual code
+    code = if defined?(IRB::Statement) && line_or_statement.kind_of?(IRB::Statement)
+             line_or_statement.code
+           else
+             line_or_statement
+           end
+
+    Console1984.command_executor.execute(Array(code)) do
       super
     end
   end


### PR DESCRIPTION
`irb` in version 1.13 started to call `@context.evaluate` with `IRB::Statement` argument instead of `String` (PR: https://github.com/ruby/irb/pull/920) and so we need to support both ways of calling `evaluate`

Fixes #110