### PR TITLE
Use new IRB extension API to add decrypt/encrypt commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
           - 33306:3306
     env:
       TARGET_DB: ${{ matrix.database }}
+      CI: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
   remote: .
   specs:
     console1984 (0.1.31)
+      irb (~> 1.13)
       parser
       rails (>= 7.0)
       rainbow
@@ -98,6 +99,10 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    io-console (0.7.2)
+    irb (1.13.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
@@ -135,6 +140,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.3)
+    psych (5.1.2)
+      stringio
     racc (1.7.1)
     rack (2.2.7)
     rack-test (2.1.0)
@@ -169,7 +176,11 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.1.0)
+    rdoc (6.6.3.1)
+      psych (>= 4.0.0)
     regexp_parser (2.8.1)
+    reline (0.5.7)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rubocop (1.54.1)
       json (~> 2.3)
@@ -200,6 +211,7 @@ GEM
     rubyzip (2.3.2)
     sqlite3 (1.6.3)
       mini_portile2 (~> 2.8.0)
+    stringio (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)

--- a/console1984.gemspec
+++ b/console1984.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rainbow'
   spec.add_dependency 'parser'
   spec.add_dependency 'rails', '>= 7.0'
+  spec.add_dependency 'irb', '~> 1.13'
 
   spec.add_development_dependency 'benchmark-ips'
   spec.add_development_dependency 'mocha'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ volumes:
 
 services:
   mysql:
-    image: mariadb:latest
+    image: mysql:8.0.31
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - db:/var/lib/mysql
-    ports: [ "127.0.0.1:33306:3306" ]
+    ports: [ "127.0.0.1:33060:3306" ]
   postgres:
     image: postgres:13.4
     environment:

--- a/lib/console1984/command_validator/.command_parser.rb
+++ b/lib/console1984/command_validator/.command_parser.rb
@@ -1,4 +1,4 @@
-# Naming class with dot so that it doesn't get loaded eagerly by Zeitwork. We want to load
+# Naming class with dot so that it doesn't get loaded eagerly by Zeitwerk. We want to load
 # only when a console session is started, when +parser+ is loaded.
 #
 # See +Console1984::Supervisor#require_dependencies+

--- a/lib/console1984/commands/decrypt.rb
+++ b/lib/console1984/commands/decrypt.rb
@@ -1,3 +1,5 @@
+require "irb/command"
+
 module Console1984::Commands
   class Decrypt < IRB::Command::Base
     include Console1984::Ext::Irb::Commands

--- a/lib/console1984/commands/decrypt.rb
+++ b/lib/console1984/commands/decrypt.rb
@@ -1,0 +1,12 @@
+module Console1984::Commands
+  class Decrypt < IRB::Command::Base
+    include Console1984::Ext::Irb::Commands
+
+    category "Console1984"
+    description "go back to protected mode, without access to encrypted information"
+
+    def execute(*)
+      decrypt!
+    end
+  end
+end

--- a/lib/console1984/commands/encrypt.rb
+++ b/lib/console1984/commands/encrypt.rb
@@ -1,0 +1,12 @@
+module Console1984::Commands
+  class Encrypt < IRB::Command::Base
+    include Console1984::Ext::Irb::Commands
+
+    category "Console1984"
+    description "go back to protected mode, without access to encrypted information"
+
+    def execute(*)
+      encrypt!
+    end
+  end
+end

--- a/lib/console1984/commands/encrypt.rb
+++ b/lib/console1984/commands/encrypt.rb
@@ -1,3 +1,5 @@
+require "irb/command"
+
 module Console1984::Commands
   class Encrypt < IRB::Command::Base
     include Console1984::Ext::Irb::Commands

--- a/lib/console1984/ext/irb/commands.rb
+++ b/lib/console1984/ext/irb/commands.rb
@@ -1,4 +1,3 @@
-# Add Console 1984 commands to IRB sessions.
 module Console1984::Ext::Irb::Commands
   include Console1984::Freezeable
 

--- a/lib/console1984/ext/irb/commands.rb
+++ b/lib/console1984/ext/irb/commands.rb
@@ -13,13 +13,4 @@ module Console1984::Ext::Irb::Commands
   def encrypt!
     shield.enable_protected_mode
   end
-
-  # This returns the last error that prevented a command execution in the console
-  # or nil if there isn't any.
-  #
-  # This is meant for internal usage when debugging legit commands that are wrongly
-  # prevented.
-  def _console_last_suspicious_command_error
-    Console1984.command_executor.last_suspicious_command_error
-  end
 end

--- a/lib/console1984/shield.rb
+++ b/lib/console1984/shield.rb
@@ -34,7 +34,8 @@ class Console1984::Shield
 
     def extend_irb
       IRB::Context.prepend(Console1984::Ext::Irb::Context)
-      Rails::ConsoleMethods.include(Console1984::Ext::Irb::Commands)
+      IRB::Command.register :decrypt!, Console1984::Commands::Decrypt
+      IRB::Command.register :encrypt!, Console1984::Commands::Encrypt
     end
 
     def extend_core_ruby

--- a/lib/console1984/supervisor.rb
+++ b/lib/console1984/supervisor.rb
@@ -1,11 +1,5 @@
 require "active_support/all"
 
-if Rails.version >= "8"
-  require "rails/console/methods"
-else
-  require "rails/console/app"
-end
-
 # Entry point to the system. In charge of installing everything
 # and starting and stopping sessions.
 class Console1984::Supervisor

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -20,7 +20,7 @@ module Dummy
 
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -50,5 +50,4 @@ development:
 test:
   <<: *default
   database: db/test.sqlite3
-
 <% end %>

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -9,10 +9,10 @@ Rails.application.configure do
   config.cache_classes = false
   config.action_view.cache_template_loading = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  # Eager loading loads your whole application. When running a single test locally,
+  # this probably isn't necessary. It's a good idea to do in a continuous integration
+  # system, or in some way before deploying your code.
+  config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
See https://github.com/ruby/irb/blob/2f42b2360dd023319519d231863860bc2fd30a8a/EXTEND_IRB.md

Rails::ConsoleMethods is deprecated in Rails 8 and will be removed eventually, so let's just use this.