### PR TITLE
Fix `ActiveRecord::Encryption` protection

### DIFF
--- a/config/protections.yml
+++ b/config/protections.yml
@@ -14,7 +14,7 @@ validations:
     protected:
       - PG
       - Mysql2
-      - ActiveRecord::ActiveRecordEncryption
+      - ActiveRecord::Encryption
   suspicious_terms:
     - console_1984
     - Console1984


### PR DESCRIPTION
It's currently possible to override the encryption context set by `console1984` to protect encrypted data. It looks like we intended to add a protection to this, but an unexisting constant was added to the protection list instead.

This commit fixes this protection by changing the protected constant from `ActiveRecord::ActiveRecordEncryption` to `ActiveRecord::Encryption`

Closes #120