### PR TITLE
Support custom encryption options for encrypted data

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ By default, sessions will be incinerated with a job 30 days after they are creat
 
 ### Eager loading
 
-When starting a console session, `console1984` will eager load all the application classes if necessary. In practice, production environments already load classes eagerly, so this won't represent any change for those.  
+When starting a console session, `console1984` will eager load all the application classes if necessary. In practice, production environments already load classes eagerly, so this won't represent any change for those.
 
 ## Configuration
 
@@ -157,6 +157,7 @@ These config options are namespaced in `config.console1984`:
 | `incinerate_after`                          | The period to keep sessions around before incinerate them. Default `30.days`.                                                                                                                                          |
 | `incineration_queue`                        | The name of the queue for session incineration jobs. Default `console1984_incineration`.                                                                                                                               |
 | `base_record_class`                         | The host application base class that will be the parent of `console1984` records. By default it's `::ApplicationRecord`. |
+| `encryption_options`                        | Extra encryption options, such as `key_provider` or `key`, used to to encrypt `console1984` command data. Defaults to `{}` |
 
 ### SSH Config
 
@@ -192,8 +193,8 @@ The test suite runs against SQLite by default, but can be run against Postgres a
 To run the suite in your computer, first, run `bin/setup` to create the docker containers for MySQL/PostgreSQL and create the databases. Then run:
 
 ```bash
-bin/rails test # against SQLite (default) 
-bin/rails test TARGET_DB=mysql 
-bin/rails test TARGET_DB=postgres 
-bin/rails test TARGET_DB=sqlite  
+bin/rails test # against SQLite (default)
+bin/rails test TARGET_DB=mysql
+bin/rails test TARGET_DB=postgres
+bin/rails test TARGET_DB=sqlite
 ```

--- a/app/models/console1984/command.rb
+++ b/app/models/console1984/command.rb
@@ -3,7 +3,7 @@ module Console1984
     belongs_to :session
     belongs_to :sensitive_access, optional: true
 
-    encrypts :statements
+    encrypts :statements, **Console1984.encryption_options
 
     scope :sorted_chronologically, -> { order(created_at: :asc, id: :asc) }
 

--- a/lib/console1984/config.rb
+++ b/lib/console1984/config.rb
@@ -14,6 +14,7 @@ class Console1984::Config
     protections_config
     base_record_class
     debug test_mode
+    encryption_options
   ]
 
   attr_accessor(*PROPERTIES)
@@ -61,5 +62,7 @@ class Console1984::Config
 
       self.debug = false
       self.test_mode = false
+
+      self.encryption_options = {}
     end
 end


### PR DESCRIPTION
Rails applications support setting per-attribute encryption options such as `key_provider` or `key`. This is useful when you want to encrypt an attribute with a different key provider than the one set up as the default.

Console1984 has no way to set these attributes, always using the application defaults.

This commit adds an `encryption_options` configuration that can add extra arguments to the `encrypts :statements` method.

In my case, the application I'm working on expects the Active Record encryption context to always be overriden with an account-specific context (one different KMS Key per account), and has an unusable, exception-raising key provider as the default one to enforce the custom encryption contexts. As console1984 (and audits1984) use the default key provider, this becomes an issue.