### PR TITLE
Add ENV protection

### DIFF
--- a/config/protections.yml
+++ b/config/protections.yml
@@ -21,6 +21,7 @@ validations:
     - secret
     - credentials
     - irb
+    - ENV
 forbidden_methods:
   Kernel:
     - eval

--- a/test/tampering_cases/flagged/ruby/env.rb
+++ b/test/tampering_cases/flagged/ruby/env.rb
@@ -1,0 +1,1 @@
+ENV['DATABASE_URL']


### PR DESCRIPTION
See https://github.com/basecamp/console1984/issues/93.

This PR aims to add to `ENV` the same protection mechanism that `credentials` currently have, since both of them share the idea of storing sensitive values in a security context. 