### PR TITLE
Fix wrong sensitive access assignment

### DIFF
--- a/lib/console1984/sessions_logger/database.rb
+++ b/lib/console1984/sessions_logger/database.rb
@@ -35,10 +35,10 @@ class Console1984::SessionsLogger::Database
 
   def after_executing(statements, tampering_attempted, unprotected_mode)
     if !tampering_attempted
-      @last_untempered_sensitive_access = @current_sensitive_access
+      @last_untampered_sensitive_access = @current_sensitive_access
     elsif tampering_attempted
       @current_sensitive_access = nil unless unprotected_mode
-      @current_sensitive_access = @last_untempered_sensitive_access if unprotected_mode
+      @current_sensitive_access = @last_untampered_sensitive_access if unprotected_mode
     end
   end
 

--- a/lib/console1984/sessions_logger/database.rb
+++ b/lib/console1984/sessions_logger/database.rb
@@ -33,7 +33,13 @@ class Console1984::SessionsLogger::Database
     end
   end
 
-  def after_executing(statements)
+  def after_executing(statements, tampering_attempted, unprotected_mode)
+    if !tampering_attempted
+      @last_untempered_sensitive_access = @current_sensitive_access
+    elsif tampering_attempted
+      @current_sensitive_access = nil unless unprotected_mode
+      @current_sensitive_access = @last_untempered_sensitive_access if unprotected_mode
+    end
   end
 
   def suspicious_commands_attempted(statements)

--- a/test/auditing_test.rb
+++ b/test/auditing_test.rb
@@ -61,14 +61,14 @@ class AuditingTest < ActiveSupport::TestCase
     assert_equal sensitive_access, last_command.sensitive_access
   end
 
-  test "a tamper attempt does not mark following legit commands as sensitive" do
+  test "a tampering attempt does not mark following legit commands as sensitive" do
     @console.execute "IRB"
     @console.execute "2+2"
 
     assert_not Console1984::Command.last.sensitive?
   end
 
-  test "in unprotected mode, a tamper attempt does not mark following legit commands as suspicious" do
+  test "in unprotected mode, a tampering attempt does not mark following legit commands as suspicious" do
     @console.execute "1+1"
 
     type_when_prompted "Checking for inconsistencies..." do
@@ -76,19 +76,19 @@ class AuditingTest < ActiveSupport::TestCase
     end
 
     @console.execute "1+1"
-    untampered_sensitive_access_id = Console1984::Command.last.sensitive_access_id
+    untamperinged_sensitive_access_id = Console1984::Command.last.sensitive_access_id
 
     @console.execute "IRB"
 
     @console.execute "2+2"
 
     assert Console1984::Command.last.sensitive?
-    assert_equal Console1984::Command.last.sensitive_access_id, untampered_sensitive_access_id
+    assert_equal Console1984::Command.last.sensitive_access_id, untamperinged_sensitive_access_id
 
     assert Console1984::Command.last.sensitive_access.justification == "Checking for inconsistencies..."
   end
 
-  test "in unprotected mode, a tamper attempt still marks following unlegit commands as suspicious, but assigned to a different sensitive access" do
+  test "in unprotected mode, a tampering attempt still marks following unlegit commands as suspicious, but assigned to a different sensitive access" do
     @console.execute "1+1"
 
     type_when_prompted "Checking for inconsistencies..." do
@@ -98,12 +98,12 @@ class AuditingTest < ActiveSupport::TestCase
     @console.execute "2+2"
 
     @console.execute "IRB"
-    tampered_sensitive_access_id = Console1984::Command.last.sensitive_access_id
+    tamperinged_sensitive_access_id = Console1984::Command.last.sensitive_access_id
 
     @console.execute "Console1984"
 
     assert Console1984::Command.last.sensitive?
-    assert_not Console1984::Command.last.sensitive_access_id == tampered_sensitive_access_id
+    assert_not Console1984::Command.last.sensitive_access_id == tamperinged_sensitive_access_id
 
     assert Console1984::Command.last.sensitive_access.justification == "Suspicious commands attempted"
   end


### PR DESCRIPTION
This PR aims to fix some sensitive access inconsistencies. The main issue being that after a tempering attempt was made in protected mode, every following command was also being flagged as sensitive (suspicious), even the legitimate ones, which of course is not the expected behavior.

Before:

<img width="779" alt="image" src="https://github.com/user-attachments/assets/a192f983-a0e0-45cf-8ffa-e0021ce39b4c">

After:

<img width="730" alt="image" src="https://github.com/user-attachments/assets/acc488cd-5979-4ba8-a46c-549ab97d0096">
