### PR TITLE
Fix IRB 1.15 compatibility

### DIFF
--- a/lib/console1984/ext/irb/context.rb
+++ b/lib/console1984/ext/irb/context.rb
@@ -5,7 +5,7 @@ module Console1984::Ext::Irb::Context
 
   # This method is invoked for showing returned objects in the console
   # Overridden to make sure their evaluation is supervised.
-  def inspect_last_value
+  def inspect_last_value(...)
     Console1984.command_executor.execute_in_protected_mode do
       super
     end


### PR DESCRIPTION
IRB started taking an optional string argument since this change: https://github.com/ruby/irb/pull/1040/files#diff-ab687ede3f7ef6d644efae4bfd7f3649ee68425f8288f195e93d9c9b239153bd

I manually tested this also works with IRB 1.14.3.

Fixes #127 