### PR TITLE
Update command_executor.rb

### DIFF
--- a/lib/console1984/command_executor.rb
+++ b/lib/console1984/command_executor.rb
@@ -20,7 +20,7 @@ class Console1984::CommandExecutor
     run_as_system { session_logger.before_executing commands }
     validate_command commands
     execute_in_protected_mode(&block)
-  rescue Console1984::Errors::ForbiddenCommandAttempted, FrozenError => error
+  rescue FrozenError => error
     flag_suspicious(commands, error: error)
   rescue Console1984::Errors::SuspiciousCommandAttempted => error
     flag_suspicious(commands, error: error)


### PR DESCRIPTION
I noticed that Console1984::Errors::ForbiddenCommandExecuted is rescued twice, the first rescue flags and the second rescue a few lines down flags and exits immediately.  I'm assuming the intent was to only rescue once and exit immediately.