### PR TITLE
Allow the sensitive access justification prompt to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ By default, sessions will be incinerated with a job 30 days after they are creat
 
 ### Eager loading
 
-When starting a console session, `console1984` will eager load all the application classes if necessary. In practice, production environments already load classes eagerly, so this won't represent any change for those.  
+When starting a console session, `console1984` will eager load all the application classes if necessary. In practice, production environments already load classes eagerly, so this won't represent any change for those.
 
 ## Configuration
 
@@ -149,10 +149,11 @@ These config options are namespaced in `config.console1984`:
 | `protected_urls`                            | The list of URLs corresponding with external systems to protect.                                                                                                                                                       |
 | `session_logger`                            | The system used to record session data. The default logger is `Console1984::SessionsLogger::Database`.                                                                                                                 |
 | `username_resolver`                         | Configure how the current user is determined for a given console session. The default is `Console1984::Username::EnvResolver.new("CONSOLE_USER")`, which returns the value of the environment variable `CONSOLE_USER`. |
- | `ask_for_username_if_empty`                 | If `true`, the console will ask for a username if it is empty. If `false`, it will raise an error if no username is set. Defaults to `false`.                                                                          |
+ | `ask_for_username_if_empty`                | If `true`, the console will ask for a username if it is empty. If `false`, it will raise an error if no username is set. Defaults to `false`.                                                                          |
 | `production_data_warning`                   | The text to show when a console session starts.                                                                                                                                                                        |
 | `enter_unprotected_encryption_mode_warning` | The text to show when user enters into unprotected mode.                                                                                                                                                               |
-| `enter_protected_mode_warning`              | The text to show when user goes back to protected mode.                                                                                                                                                                 |
+| `enter_protected_mode_warning`              | The text to show when user goes back to protected mode.                                                                                                                                                                |
+| `sensitive_access_justification_prompt`     | The text to show when asking the user for justification to enter unprotected mode.                                                                                                                                     |
 | `incinerate`                                | Whether incinerate sessions automatically after a period of time or not. Default to `true`.                                                                                                                            |
 | `incinerate_after`                          | The period to keep sessions around before incinerate them. Default `30.days`.                                                                                                                                          |
 | `incineration_queue`                        | The name of the queue for session incineration jobs. Default `console1984_incineration`.                                                                                                                               |
@@ -192,8 +193,8 @@ The test suite runs against SQLite by default, but can be run against Postgres a
 To run the suite in your computer, first, run `bin/setup` to create the docker containers for MySQL/PostgreSQL and create the databases. Then run:
 
 ```bash
-bin/rails test # against SQLite (default) 
-bin/rails test TARGET_DB=mysql 
-bin/rails test TARGET_DB=postgres 
-bin/rails test TARGET_DB=sqlite  
+bin/rails test # against SQLite (default)
+bin/rails test TARGET_DB=mysql
+bin/rails test TARGET_DB=postgres
+bin/rails test TARGET_DB=sqlite
 ```

--- a/lib/console1984/config.rb
+++ b/lib/console1984/config.rb
@@ -9,7 +9,7 @@ class Console1984::Config
   PROPERTIES = %i[
     session_logger username_resolver ask_for_username_if_empty shield command_executor
     protected_environments protected_urls
-    production_data_warning enter_unprotected_encryption_mode_warning enter_protected_mode_warning
+    production_data_warning enter_unprotected_encryption_mode_warning enter_protected_mode_warning sensitive_access_justification_prompt
     incinerate incinerate_after incineration_queue
     protections_config
     base_record_class
@@ -51,6 +51,7 @@ class Console1984::Config
       self.production_data_warning = DEFAULT_PRODUCTION_DATA_WARNING
       self.enter_unprotected_encryption_mode_warning = DEFAULT_ENTER_UNPROTECTED_ENCRYPTION_MODE_WARNING
       self.enter_protected_mode_warning = DEFAULT_ENTER_PROTECTED_MODE_WARNING
+      self.sensitive_access_justification_prompt = DEFAULT_SENSITIVE_ACCESS_JUSTIFICATION_PROMPT
 
       self.incinerate = true
       self.incinerate_after = 30.days

--- a/lib/console1984/messages.rb
+++ b/lib/console1984/messages.rb
@@ -14,6 +14,10 @@ module Console1984::Messages
   Great! You are back in protected mode. When we audit, we may reach out for a conversation about the commands you entered. What went well? Did you solve the problem without accessing personal data?
   TXT
 
+  DEFAULT_SENSITIVE_ACCESS_JUSTIFICATION_PROMPT = <<~TXT
+  \nBefore you can access personal information, you need to ask for and get explicit consent from the user(s). Where can we find this consent (a URL would be great)?
+  TXT
+
   COMMANDS = {
       "decrypt!": "enter unprotected mode with access to encrypted information"
   }

--- a/lib/console1984/shield/modes.rb
+++ b/lib/console1984/shield/modes.rb
@@ -17,7 +17,7 @@ module Console1984::Shield::Modes
   def enable_unprotected_mode(silent: false)
     command_executor.run_as_system do
       show_warning Console1984.enter_unprotected_encryption_mode_warning if !silent && protected_mode?
-      justification = ask_for_value "\nBefore you can access personal information, you need to ask for and get explicit consent from the user(s). #{current_username}, where can we find this consent (a URL would be great)?"
+      justification = ask_for_value Console1984.sensitive_access_justification_prompt
       session_logger.start_sensitive_access justification
       nil
     end


### PR DESCRIPTION
Firstly, thanks for the work on this gem, its great!

I was thinking that it would be great if the prompt when asking for justification for using the `decrypt!` command could be customised in the config. This PR is my attempt at implementing that. The only issue I can see with my approach is it loses the personalisation that the original implementation had by interpolating the current user name into the prompt. 