### PR TITLE
Use Reline to read reason

### DIFF
--- a/lib/console1984/input_output.rb
+++ b/lib/console1984/input_output.rb
@@ -31,7 +31,7 @@ module Console1984::InputOutput
 
     def ask_for_value(message)
       puts Rainbow("#{message}").green
-      reason = $stdin.gets.strip until reason.present?
+      reason = Reline.readline.strip until reason.present?
       reason
     end
 end

--- a/test/support/io_stream_test_helper.rb
+++ b/test/support/io_stream_test_helper.rb
@@ -1,5 +1,5 @@
 module IoStreamTestHelper
   def type_when_prompted(*list, &block)
-    $stdin.stub(:gets, proc { list.shift }, &block)
+    Reline.stub(:readline, proc { list.shift }, &block)
   end
 end


### PR DESCRIPTION
`$stdin` has trouble displaying multibyte characters. Reline (which console1984 already depends on) doesn't have the problem.