### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/console1984/command_validator/.command_parser.rb
+++ b/lib/console1984/command_validator/.command_parser.rb
@@ -56,7 +56,7 @@ class Console1984::CommandValidator::CommandParser < ::Parser::AST::Processor
 
   def on_casgn(node)
     super
-    scope_node, name, value_node = *node
+    _, _, value_node = *node
     @constant_assignments.push(*extract_constants(value_node))
   end
 

--- a/test/support/supervised_test_console.rb
+++ b/test/support/supervised_test_console.rb
@@ -37,7 +37,7 @@ class SupervisedTestConsole
   private
     def simulate_evaluation(statement)
       simulated_console.instance_eval statement
-    rescue NoMethodError => e
+    rescue NoMethodError
       eval(statement)
     end
 


### PR DESCRIPTION
## Summary

Fix Ruby warnings for assigned but unused variables:

```
test/support/supervised_test_console.rb:40: warning: assigned but unused variable - e
lib/console1984/command_validator/.command_parser.rb:59: warning: assigned but unused variable - scope_node
lib/console1984/command_validator/.command_parser.rb:59: warning: assigned but unused variable - name
```