### PR TITLE
Audit rails query invocations and tag agent-driven runs

### DIFF
--- a/lib/console1984/engine.rb
+++ b/lib/console1984/engine.rb
@@ -24,5 +24,12 @@ module Console1984
         Console1984.supervisor.start
       end
     end
+
+    # Audit `rails query` invocations via ActiveSupport::Notifications. The
+    # subscriber no-ops outside protected environments, so it's safe to
+    # register unconditionally.
+    initializer "console1984.query_auditor" do
+      Console1984::QueryAuditor.install
+    end
   end
 end

--- a/lib/console1984/engine.rb
+++ b/lib/console1984/engine.rb
@@ -25,9 +25,6 @@ module Console1984
       end
     end
 
-    # Audit `rails query` invocations via ActiveSupport::Notifications. The
-    # subscriber no-ops outside protected environments, so it's safe to
-    # register unconditionally.
     initializer "console1984.query_auditor" do
       Console1984::QueryAuditor.install
     end

--- a/lib/console1984/query_auditor.rb
+++ b/lib/console1984/query_auditor.rb
@@ -1,15 +1,7 @@
-# Subscribes to the `query.rails` notifications emitted by the `rails query`
-# command (Rails 8.2+) and records each invocation as a session in the
-# configured session logger. Includes the expression or sub-command
-# (`schema`, `models`, `explain`) as the executed statement, and — when
-# detected — flags the agent that triggered the run so audit trails
-# distinguish between human and agent-driven queries.
 class Console1984::QueryAuditor
-  # Env vars that identify a known coding agent is orchestrating the run.
-  # Add entries via Console1984::QueryAuditor.known_agents[env_var] = label.
   mattr_accessor :known_agents, default: {
-    "CLAUDECODE"       => "Claude Code",
-    "CODEX_THREAD_ID"  => "Codex"
+    "CLAUDECODE"      => "Claude Code",
+    "CODEX_THREAD_ID" => "Codex"
   }
 
   def self.install

--- a/lib/console1984/query_auditor.rb
+++ b/lib/console1984/query_auditor.rb
@@ -1,0 +1,48 @@
+# Subscribes to the `query.rails` notifications emitted by the `rails query`
+# command (Rails 8.2+) and records each invocation as a session in the
+# configured session logger. Includes the expression or sub-command
+# (`schema`, `models`, `explain`) as the executed statement, and — when
+# detected — flags the agent that triggered the run so audit trails
+# distinguish between human and agent-driven queries.
+class Console1984::QueryAuditor
+  # Env vars that identify a known coding agent is orchestrating the run.
+  # Add entries via Console1984::QueryAuditor.known_agents[env_var] = label.
+  mattr_accessor :known_agents, default: {
+    "CLAUDECODE"       => "Claude Code",
+    "CODEX_THREAD_ID"  => "Codex"
+  }
+
+  def self.install
+    ActiveSupport::Notifications.subscribe("query.rails", new)
+  end
+
+  def start(name, id, payload)
+    return unless Console1984.running_protected_environment?
+
+    Console1984.session_logger.start_session(resolved_username, session_reason)
+    Console1984.session_logger.before_executing([ payload[:expression].to_s ])
+  end
+
+  def finish(name, id, payload)
+    return unless Console1984.running_protected_environment?
+
+    Console1984.session_logger.finish_session
+  end
+
+  private
+    def resolved_username
+      Console1984.username_resolver.current.presence || "unknown"
+    end
+
+    def session_reason
+      if agent = detected_agent
+        "rails query (via #{agent})"
+      else
+        "rails query"
+      end
+    end
+
+    def detected_agent
+      ENV["QUERY_AGENT"].presence || known_agents.find { |var, _| ENV[var].present? }&.last
+    end
+end

--- a/lib/console1984/query_auditor.rb
+++ b/lib/console1984/query_auditor.rb
@@ -43,6 +43,6 @@ class Console1984::QueryAuditor
     end
 
     def detected_agent
-      ENV["QUERY_AGENT"].presence || known_agents.find { |var, _| ENV[var].present? }&.last
+      known_agents.find { |var, _| ENV[var].present? }&.last
     end
 end

--- a/test/query_auditor_test.rb
+++ b/test/query_auditor_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class QueryAuditorTest < ActiveSupport::TestCase
   setup do
     @auditor = Console1984::QueryAuditor.new
+    Console1984.username_resolver.username = "jorge"
   end
 
   test "records a session with rails query reason when no agent detected" do

--- a/test/query_auditor_test.rb
+++ b/test/query_auditor_test.rb
@@ -6,7 +6,7 @@ class QueryAuditorTest < ActiveSupport::TestCase
   end
 
   test "records a session with rails query reason when no agent detected" do
-    with_env "CLAUDECODE" => nil, "CODEX_THREAD_ID" => nil, "QUERY_AGENT" => nil do
+    with_env "CLAUDECODE" => nil, "CODEX_THREAD_ID" => nil do
       assert_difference -> { Console1984::Session.count }, +1 do
         simulate_query_notification "Account.count"
       end
@@ -23,19 +23,11 @@ class QueryAuditorTest < ActiveSupport::TestCase
   end
 
   test "labels sessions triggered by known agent env vars" do
-    with_env "CLAUDECODE" => "1", "QUERY_AGENT" => nil do
+    with_env "CLAUDECODE" => "1" do
       simulate_query_notification "Account.count"
     end
 
     assert_equal "rails query (via Claude Code)", Console1984::Session.last.reason
-  end
-
-  test "QUERY_AGENT override wins over known agent detection" do
-    with_env "CLAUDECODE" => "1", "QUERY_AGENT" => "my-bot" do
-      simulate_query_notification "Account.count"
-    end
-
-    assert_equal "rails query (via my-bot)", Console1984::Session.last.reason
   end
 
   private

--- a/test/query_auditor_test.rb
+++ b/test/query_auditor_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class QueryAuditorTest < ActiveSupport::TestCase
+  setup do
+    @auditor = Console1984::QueryAuditor.new
+  end
+
+  test "records a session with rails query reason when no agent detected" do
+    with_env "CLAUDECODE" => nil, "CODEX_THREAD_ID" => nil, "QUERY_AGENT" => nil do
+      assert_difference -> { Console1984::Session.count }, +1 do
+        simulate_query_notification "Account.count"
+      end
+
+      assert_equal "rails query", Console1984::Session.last.reason
+      assert_equal "jorge", Console1984::Session.last.user.username
+    end
+  end
+
+  test "records the expression as a command" do
+    simulate_query_notification "Account.where(fake: false).count"
+
+    assert_equal "Account.where(fake: false).count", Console1984::Command.last.statements
+  end
+
+  test "labels sessions triggered by known agent env vars" do
+    with_env "CLAUDECODE" => "1", "QUERY_AGENT" => nil do
+      simulate_query_notification "Account.count"
+    end
+
+    assert_equal "rails query (via Claude Code)", Console1984::Session.last.reason
+  end
+
+  test "QUERY_AGENT override wins over known agent detection" do
+    with_env "CLAUDECODE" => "1", "QUERY_AGENT" => "my-bot" do
+      simulate_query_notification "Account.count"
+    end
+
+    assert_equal "rails query (via my-bot)", Console1984::Session.last.reason
+  end
+
+  private
+    def simulate_query_notification(expression)
+      @auditor.start("query.rails", "id", { expression: expression })
+      @auditor.finish("query.rails", "id", { expression: expression })
+    end
+
+    def with_env(vars)
+      before = vars.keys.index_with { |key| ENV[key] }
+      vars.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+      yield
+    ensure
+      before.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    end
+end


### PR DESCRIPTION
## Summary

Adds an audit subscriber for the `rails query` command introduced in [rails/rails#57156](https://github.com/rails/rails/pull/57156) (Rails 8.2+). Each `rails query` invocation is recorded as a session in the configured session logger — same audit trail as `rails console`.

When a known coding-agent env var is present in the environment, its label is appended to the session reason so audit trails can distinguish human from agent-driven queries:

- `CLAUDECODE=1` → `rails query (via Claude Code)`
- `CODEX_THREAD_ID=<uuid>` → `rails query (via Codex)`

Both env markers were verified by inspecting a live agent session. The map is configurable:

```ruby
Console1984::QueryAuditor.known_agents["CURSOR_AGENT"] = "Cursor"
```

The subscriber no-ops outside protected environments, so it's safe to register unconditionally from the engine.

<img width="1035" height="713" alt="image" src="https://github.com/user-attachments/assets/40d7d20b-7757-46e0-b2b1-231bf41eb9e6" />

## Context

Haystack and Queenbee both ship a copy of this subscriber today as an app-level initializer. Upstreaming avoids the duplication and gives any console1984 consumer on Rails 8.2+ the audit trail for free.

## Test plan

- [x] `bundle exec rails test` — 83 runs, 0 failures, 0 errors
- [x] Tests cover session creation, expression recording, and known-agent detection