### PR TITLE
Store freeze opt-out flag outside IsolatedExecutionState

### DIFF
--- a/lib/console1984/freezeable.rb
+++ b/lib/console1984/freezeable.rb
@@ -23,8 +23,19 @@ module Console1984::Freezeable
     base.extend ClassMethods
 
     # Flag to control manipulating instance data via instance_variable_get and instance_variable_set.
-    # true by default.
-    base.thread_mattr_accessor :prevent_instance_data_manipulation_after_freezing, default: true
+    # true by default. Stored as a singleton-class instance variable on the host so it survives
+    # +ActiveSupport::IsolatedExecutionState+ being cleared when Rails switches +isolation_level+
+    # (e.g. the +:thread+ -> +:fiber+ flip the Rails 8.1 default triggers in +after_initialize+).
+    # A +mattr_accessor+ would leak the flag across the ancestor chain because +Console1984::Ext::Core::Object+
+    # is included into +Object+; this storage keeps each host independent.
+    base.singleton_class.class_eval do
+      attr_writer :prevent_instance_data_manipulation_after_freezing
+
+      define_method :prevent_instance_data_manipulation_after_freezing do
+        return @prevent_instance_data_manipulation_after_freezing if defined?(@prevent_instance_data_manipulation_after_freezing)
+        true
+      end
+    end
   end
 
   module ClassMethods

--- a/test/freezeable_test.rb
+++ b/test/freezeable_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class FreezeableTest < ActiveSupport::TestCase
+  test "prevent_instance_data_manipulation_after_freezing defaults to true" do
+    klass = Class.new { include Console1984::Freezeable }
+
+    assert_equal true, klass.prevent_instance_data_manipulation_after_freezing
+  end
+
+  test "prevent_instance_data_manipulation_after_freezing survives ActiveSupport::IsolatedExecutionState being cleared" do
+    # Reproduces the Rails 8.1 boot symptom: gem eager-load writes the opt-out under one
+    # +isolation_level+, then Rails switches the level in +after_initialize+ which clears
+    # the previous scope's storage. The write must survive.
+    klass = Class.new do
+      include Console1984::Freezeable
+      self.prevent_instance_data_manipulation_after_freezing = false
+    end
+
+    ActiveSupport::IsolatedExecutionState.clear
+
+    assert_equal false, klass.prevent_instance_data_manipulation_after_freezing
+  end
+
+  test "prevent_instance_data_manipulation_after_freezing is independent per including host" do
+    one = Class.new { include Console1984::Freezeable }
+    two = Class.new { include Console1984::Freezeable }
+
+    one.prevent_instance_data_manipulation_after_freezing = false
+
+    assert_equal false, one.prevent_instance_data_manipulation_after_freezing
+    assert_equal true, two.prevent_instance_data_manipulation_after_freezing
+  end
+
+  test "Console1984::Ext::Core::Object opt-out does not leak into other Freezeable hosts" do
+    # Object includes Console1984::Ext::Core::Object, which sets the flag to false. A class-variable-backed
+    # accessor would propagate that false through Ruby's ancestor chain to every descendant of Object,
+    # silently disabling the protection on every other Freezeable host.
+    assert_equal false, Console1984::Ext::Core::Object.prevent_instance_data_manipulation_after_freezing
+    assert_equal true, Console1984::Config.prevent_instance_data_manipulation_after_freezing
+  end
+end


### PR DESCRIPTION
We saw our prod consoles starting to break after switching to fiber isolation. This happened immediately when Rails tries to connect to postgres.

The flag was a thread_mattr_accessor, which routes through ActiveSupport::IsolatedExecutionState. Rails 8.1 defaults isolation_level to :fiber and flips it inside after_initialize, the setter clears the old scope's storage before swapping, wiping the false written at eager-load by Ext::Core::Object and Ext::Core::String.

The default true then takes over and Refrigerator#freeze_all installs instance_variable_get/set overrides on Object, breaking anything that introspects ivars (e.g. the postgres adapter in destroy_all/update_all).

Storing the flag in a singleton-class ivar on the host keeps each Freezeable independent (which is why mattr_accessor was avoided here, its class variable would leak through Object's ancestor chain) and is unaffected by the isolation_level switch.