### PR TITLE
Fix auditable-tables shield crashing on insert_all/upsert_all

### DIFF
--- a/lib/console1984/ext/active_record/protected_auditable_tables.rb
+++ b/lib/console1984/ext/active_record/protected_auditable_tables.rb
@@ -5,7 +5,7 @@ module Console1984::Ext::ActiveRecord::ProtectedAuditableTables
   %i[ execute exec_query exec_insert exec_delete exec_update exec_insert_all ].each do |method|
     define_method method do |*args, **kwargs|
       sql = args.first
-      if Console1984.command_executor.executing_user_command? && sql.b =~ auditable_tables_regexp
+      if Console1984.command_executor.executing_user_command? && auditable_sql(sql) =~ auditable_tables_regexp
         raise Console1984::Errors::ForbiddenCommandAttempted, "#{sql}"
       else
         super(*args, **kwargs)
@@ -14,6 +14,14 @@ module Console1984::Ext::ActiveRecord::ProtectedAuditableTables
   end
 
   private
+    # exec_insert_all receives an ActiveRecord::InsertAll, not a SQL string, so
+    # #b is undefined on it. Check its target table name instead, so insert_all
+    # and upsert_all don't blow up when run from the console.
+    def auditable_sql(sql)
+      string = sql.is_a?(String) ? sql : (sql.try(:model)&.table_name || sql.to_s)
+      string.b
+    end
+
     def auditable_tables_regexp
       @auditable_tables_regexp ||= Regexp.new("#{auditable_tables.join("|")}")
     end

--- a/test/ext/active_record/protected_auditable_tables_test.rb
+++ b/test/ext/active_record/protected_auditable_tables_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class Console1984::Ext::ActiveRecord::ProtectedAuditableTablesTest < ActiveSupport::TestCase
+  # Stands in for the underlying adapter; the shield is prepended on top.
+  class FakeConnection
+    attr_reader :received
+
+    def exec_insert_all(*args, **kwargs)
+      @received = args.first
+      :executed
+    end
+
+    prepend Console1984::Ext::ActiveRecord::ProtectedAuditableTables
+  end
+
+  # Mimics what exec_insert_all actually receives: an ActiveRecord::InsertAll,
+  # which responds to #model but not to #b.
+  InsertAll = Struct.new(:model)
+
+  setup do
+    # Make sure the audit models are loaded so auditable_tables_regexp isn't empty.
+    [ Console1984::Session, Console1984::Command, Console1984::SensitiveAccess, Console1984::User ]
+    @connection = FakeConnection.new
+  end
+
+  test "an InsertAll for a non-auditable table is allowed and passed through untouched" do
+    insert_all = InsertAll.new(Person)
+
+    result = as_user { @connection.exec_insert_all(insert_all, "Person Bulk Insert") }
+
+    assert_equal :executed, result
+    assert_same insert_all, @connection.received
+  end
+
+  test "an InsertAll for an auditable table is still forbidden" do
+    insert_all = InsertAll.new(Console1984::Session)
+
+    assert_raises Console1984::Errors::ForbiddenCommandAttempted do
+      as_user { @connection.exec_insert_all(insert_all, "Session Bulk Insert") }
+    end
+  end
+
+  test "string SQL is still checked against auditable tables" do
+    assert_raises Console1984::Errors::ForbiddenCommandAttempted do
+      as_user { @connection.exec_insert_all("INSERT INTO console1984_sessions (reason) VALUES ('x')", "x") }
+    end
+
+    assert_equal :executed, as_user { @connection.exec_insert_all("INSERT INTO people (name) VALUES ('x')", "x") }
+  end
+
+  private
+    def as_user(&block)
+      Console1984.command_executor.run_as_user(&block)
+    end
+end


### PR DESCRIPTION
## Problem

The auditable-tables shield (`ProtectedAuditableTables`) wraps the connection's query methods and does:

```ruby
sql = args.first
if Console1984.command_executor.executing_user_command? && sql.b =~ auditable_tables_regexp
```

It assumes `args.first` is a SQL **String**. But `exec_insert_all` receives an `ActiveRecord::InsertAll`, which doesn't respond to `#b`. So **any `insert_all`/`upsert_all` run from an audited console** raises:

```
NoMethodError: undefined method 'b' for an instance of ActiveRecord::InsertAll
```

It's invisible in normal web/job traffic because the check is short-circuited by `executing_user_command?` — it only bites in the console. In practice it blows up routine maintenance: e.g. updating a record whose callbacks `insert_all` (assignment summaries, backlinks, …) dies mid-way, sometimes rolling back the whole transaction.

## Fix

Coerce the argument before the auditable-tables check. For a non-String, use its target table name (`InsertAll#model.table_name`) so the regexp still correctly detects — and forbids — access to audited tables. The underlying adapter still receives the **original** argument untouched, and string SQL behavior is unchanged.

```ruby
def auditable_sql(sql)
  string = sql.is_a?(String) ? sql : (sql.try(:model)&.table_name || sql.to_s)
  string.b
end
```

## Tests

Added `test/ext/active_record/protected_auditable_tables_test.rb`:
- an `InsertAll`-shaped arg for a non-auditable table is allowed and passed through untouched (the regression);
- an `InsertAll` for an auditable table is still forbidden;
- string SQL is still checked against auditable tables (unchanged).

Full suite: **86 runs, 374 assertions, 0 failures, 0 errors**. `bin/rubocop` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)